### PR TITLE
Docs: Update qcs crate README to be more descriptive on crates.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Most development tasks are automated with [cargo-make] (like make, but you can h
 
 In order to run all checks exactly the same way that CI does, use `makers workspace-ci-flow` from the project root (workspace).
 
+### Dependencies
+
+Because this library relies on [ØMQ], [`cmake`] is required:
+
+- macOS [Homebrew] : `brew install cmake`
+- Windows [Chocolatey]: `choco install cmake`
+- Debian: `apt install cmake`
+
 ### Running Tests
 
 The best way to go about this is via `makers` or `cargo make` with no task. This will default to `dev-test-flow` which formats all code, builds, and tests everything.

--- a/qcs/README.md
+++ b/qcs/README.md
@@ -1,6 +1,14 @@
-A high level interface for running programs on a QPU.
+# QCS Rust SDK
 
-# Setup
+The `qcs` crate is a high-level interface to Rigetti's [Quantum Cloud Services], allowing Rust developers to run [Quil] programs on Rigetti's [QPUs]. This crate is a Rust port of [`pyQuil`], though it currently has a much smaller feature set.
 
-In order to build from source, you need to have `cmake` installed (`brew install cmake`).
+## Documentation
 
+This crate is documented primarily via [rustdoc] comments and examples, which are available on [docs.rs].
+
+[Quantum Cloud Services]: https://docs.rigetti.com/qcs/
+[Quil]: https://github.com/quil-lang/quil
+[QPUs]: https://qcs.rigetti.com/qpus/
+[`pyQuil`]: https://github.com/rigetti/pyquil
+[rustdoc]: https://doc.rust-lang.org/rustdoc/index.html
+[docs.rs]: https://docs.rs/qcs


### PR DESCRIPTION
Also, move build instructions into workspace README.