### PR TITLE
feat: Add `compile_with_quilc` option on `Executable` to support Quil-T.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,13 @@ default:
 run-examples:
   stage: test
   image: rust
+  services:
+    - alias: qvm
+      name: rigetti/qvm
+      command: [ "-S" ]
+    - alias: quilc
+      name: rigetti/quilc
+      command: [ "-S" ]
   before_script:
     - rustc --version
     - cargo --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,5 +10,10 @@ default:
 run-examples:
   stage: test
   image: rust
+  before_script:
+    - rustc --version
+    - cargo --version
+    - apt update
+    - apt install cmake -y
   script:
     - cargo run --example parametric_compilation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,10 @@
 stages:
   - test
 
+default:
+  tags:
+    - ec2-docker
+
 run-examples:
   stage: test
   image: rust

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+# Runs tests that require a connection to a real QPU
+
+stages:
+  - test
+
+run-examples:
+  stage: test
+  image: rust
+  script:
+    - cargo run --example parametric_compilation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,3 +24,4 @@ run-examples:
     - apt install cmake -y
   script:
     - cargo run --example parametric_compilation
+    - cargo run --example quil_t

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,5 @@
 [env]
+RUST_BACKTRACE = 0
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 
 [tasks.lint]

--- a/qcs/examples/parametric_compilation.rs
+++ b/qcs/examples/parametric_compilation.rs
@@ -27,12 +27,12 @@ async fn main() {
         let theta = step * f64::from(i);
         let result = exe
             .with_parameter("theta", 0, theta)
-            .execute_on_qpu("Aspen-9")
+            .execute_on_qpu("Aspen-11")
             .await
             .expect("Failed to execute")
             .remove("ro")
             .expect("Missing ro register");
-        parametric_measurements.append(&mut result.into_i8().unwrap()[0])
+        parametric_measurements.append(&mut result.into_i16().unwrap()[0])
     }
 
     for measurement in parametric_measurements {

--- a/qcs/examples/quil_t.rs
+++ b/qcs/examples/quil_t.rs
@@ -18,7 +18,7 @@ async fn main() {
     let exe = Executable::from_quil(PROGRAM);
 
     let result = exe
-        .skip_quilc()
+        .compile_with_quilc(false)
         .execute_on_qpu("Aspen-11")
         .await
         .expect("Failed to execute")

--- a/qcs/examples/quil_t.rs
+++ b/qcs/examples/quil_t.rs
@@ -1,0 +1,29 @@
+//! This example runs a basic [Quil-T program from pyQuil][pyquil] in Rust.
+//!
+//! [pyquil]: https://pyquil-docs.rigetti.com/en/stable/quilt_getting_started.html#Another-example:-a-simple-T1-experiment
+
+use qcs::Executable;
+
+/// This program doesn't do much, the main point is that it will fail if quilc is invoked.
+const PROGRAM: &str = r#"
+DECLARE ro BIT
+RX(pi) 0
+FENCE 0
+DELAY 0 "rf" 1e-6
+MEASURE 0 ro
+"#;
+
+#[tokio::main]
+async fn main() {
+    let exe = Executable::from_quil(PROGRAM);
+
+    let result = exe
+        .skip_quilc()
+        .execute_on_qpu("Aspen-11")
+        .await
+        .expect("Failed to execute")
+        .remove("ro")
+        .expect("Missing ro register");
+
+    assert!(result.as_i16().is_some());
+}

--- a/qcs/src/executable.rs
+++ b/qcs/src/executable.rs
@@ -222,7 +222,8 @@ impl Executable<'_, '_> {
         self
     }
 
-    /// If set, the Executable is assumed to be native quil and wil skip calls to quilc.
+    /// If set, the Executable will be compiled using `quilc` prior to compilation on QCS. If not set, the program
+    /// is treated as native quil and will not be sent to `quilc`.
     #[must_use]
     pub fn compile_with_quilc(mut self, compile: bool) -> Self {
         self.compile_with_quilc = compile;

--- a/qcs/src/qpu/execution.rs
+++ b/qcs/src/qpu/execution.rs
@@ -79,7 +79,7 @@ impl<'a> Execution<'a> {
         shots: u16,
         quantum_processor_id: &'a str,
         config: &Configuration,
-        skip_quilc: bool,
+        compile_with_quilc: bool,
     ) -> Result<Execution<'a>, Error> {
         let isa = get_isa(quantum_processor_id, config)
             .await
@@ -88,13 +88,13 @@ impl<'a> Execution<'a> {
                 retry_after: None,
             })?;
 
-        let native_quil = if skip_quilc {
-            trace!("Skipping conversion to Native Quil");
-            NativeQuil::assume_native_quil(String::from(quil))
-        } else {
+        let native_quil = if compile_with_quilc {
             trace!("Converting to Native Quil");
             quilc::compile_program(quil, &isa, config)
                 .wrap_err("When attempting to compile your program to Native Quil")?
+        } else {
+            trace!("Skipping conversion to Native Quil");
+            NativeQuil::assume_native_quil(String::from(quil))
         };
 
         let program =

--- a/qcs/src/qpu/quilc/mod.rs
+++ b/qcs/src/qpu/quilc/mod.rs
@@ -51,6 +51,13 @@ pub(crate) fn compile_program(
 /// Quil which has been processed through `quilc`.
 pub struct NativeQuil(String);
 
+impl NativeQuil {
+    /// Cast a String to `NativeQuil` without checking or transforming it via `quilc`.
+    pub(super) fn assume_native_quil(quil: String) -> Self {
+        NativeQuil(quil)
+    }
+}
+
 impl From<NativeQuil> for String {
     fn from(native_quil: NativeQuil) -> String {
         native_quil.0


### PR DESCRIPTION
Closes #56

### TODO

- [x] Get up GitLab CI to run examples that utilize `quilc`
- [x] Add an option to disable `quilc`
- [x] Create an example using Quil-T sans `quilc`