### PR TITLE
fix: Stop blocking the async runtime when connecting to quilc or a QPU.

### DIFF
--- a/qcs/src/qpu/execution.rs
+++ b/qcs/src/qpu/execution.rs
@@ -98,7 +98,7 @@ impl<'a> Execution<'a> {
                     .wrap_err("When attempting to compile your program to Native Quil")
             })
             .await
-            .map_err(|_| eyre!("Error in quilc thread."))??
+            .map_err(|_| eyre!("Task running quilc did not complete."))??
         } else {
             trace!("Skipping conversion to Native Quil");
             NativeQuil::assume_native_quil(quil.to_string())

--- a/qcs/src/qpu/quilc/isa/qubit.rs
+++ b/qcs/src/qpu/quilc/isa/qubit.rs
@@ -256,41 +256,12 @@ fn rz_gates(node_id: i32) -> Vec<Operator> {
 
 #[cfg(test)]
 mod describe_rz_gates {
-    use qcs_api::models::OperationSite;
-
-    use super::*;
+    use super::{rz_gates, Arguments, Operator, Parameters};
 
     /// This data is copied from the pyQuil ISA integration test.
     #[test]
     fn it_passes_the_pyquil_aspen_8_test() {
         let node_id = 1;
-        let frb_sim_1q = Operation {
-            characteristics: vec![],
-            name: "randomized_benchmark_simultaneous_1q".to_string(),
-            node_count: Some(30),
-            parameters: vec![],
-            sites: vec![OperationSite {
-                characteristics: vec![
-                    Characteristic {
-                        name: "fRB".to_string(),
-                        value: 0.989821537688075,
-                        error: Some(0.000699235456806402),
-                        node_ids: Some(vec![0]),
-                        parameter_values: None,
-                        timestamp: "1970-01-01T00:00:00+00:00".to_string(),
-                    },
-                    Characteristic {
-                        name: "fRB".to_string(),
-                        value: 0.996832638579018,
-                        error: Some(0.00010089678215399),
-                        node_ids: Some(vec![1]),
-                        timestamp: "1970-01-01T00:00:00+00:00".to_string(),
-                        parameter_values: None,
-                    },
-                ],
-                node_ids: vec![0, 1],
-            }],
-        };
         let gates = rz_gates(node_id);
         let expected = vec![Operator::Gate {
             arguments: Arguments::Int(1),

--- a/qcs/src/qpu/runner.rs
+++ b/qcs/src/qpu/runner.rs
@@ -60,7 +60,7 @@ struct QPUParams<'request> {
 }
 
 impl<'request> QPUParams<'request> {
-    fn from_program(program: &'request str, patch_values: PatchValues<'request>) -> Self {
+    fn from_program(program: &'request str, patch_values: &'request Parameters) -> Self {
         Self {
             request: QPURequest::from_program(program, patch_values),
             priority: 1,
@@ -74,18 +74,16 @@ impl<'params> From<&'params QPUParams<'params>> for RPCRequest<'params, QPUParam
     }
 }
 
-type PatchValues<'request> = &'request HashMap<&'request str, Vec<f64>>;
-
 #[derive(Serialize, Debug)]
 #[serde(tag = "_type")]
 struct QPURequest<'request> {
     id: String,
     program: &'request str,
-    patch_values: PatchValues<'request>,
+    patch_values: &'request Parameters,
 }
 
 impl<'request> QPURequest<'request> {
-    fn from_program(program: &'request str, patch_values: PatchValues<'request>) -> Self {
+    fn from_program(program: &'request str, patch_values: &'request Parameters) -> Self {
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             program,

--- a/qcs/tests/mocked_qpu.rs
+++ b/qcs/tests/mocked_qpu.rs
@@ -43,6 +43,7 @@ async fn setup() {
     tokio::spawn(mock_qcs::run());
 }
 
+#[allow(dead_code)]
 mod auth_server {
     use serde::{Deserialize, Serialize};
     use warp::Filter;
@@ -74,6 +75,7 @@ mod auth_server {
     }
 }
 
+#[allow(dead_code)]
 mod mock_qcs {
     use serde::{Deserialize, Serialize};
     use warp::Filter;
@@ -157,6 +159,7 @@ mod mock_qcs {
     }
 }
 
+#[allow(dead_code)]
 mod qpu {
     use std::collections::HashMap;
 


### PR DESCRIPTION
Closes #31

This basically introduces threads to run all the RPCQ connections inside of. As a result, there's some `Arc`ing and `Box`ing. This PR will result in a bit slower performance overall but I think it's well worth it to not block the runtime. Importantly, this also enables callers to use timeouts if they want to give up eventually rather than waiting forever.