### PR TITLE
feat: Replace `eyre` with `thiserror` for all errors.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,16 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
-name = "eyre"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,12 +561,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1002,7 +986,6 @@ dependencies = [
  "enum-as-inner",
  "env_logger",
  "erased-serde",
- "eyre",
  "float-cmp",
  "futures",
  "hex",

--- a/qcs/Cargo.toml
+++ b/qcs/Cargo.toml
@@ -14,7 +14,6 @@ manual-tests = []
 [dependencies]
 dirs = "4.0.0"
 enum-as-inner = "0.4.0"
-eyre = "0.6.7"
 futures = "0.3.21"
 indexmap = "1.8.1"
 lazy_static = "1.4.0"

--- a/qcs/src/configuration/path.rs
+++ b/qcs/src/configuration/path.rs
@@ -1,14 +1,14 @@
 use std::path::PathBuf;
 
-use eyre::{eyre, Result};
+use super::LoadError;
 
-pub(crate) fn path_from_env_or_home(env: &str, file_name: &str) -> Result<PathBuf> {
+pub(crate) fn path_from_env_or_home(env: &str, file_name: &str) -> Result<PathBuf, LoadError> {
     match std::env::var(env) {
         Ok(path) => Ok(PathBuf::from(path)),
         Err(_) => dirs::home_dir()
             .map(|path| path.join(".qcs").join(file_name))
-            .ok_or_else(||
-                eyre!("Failed to determine home directory. You can use an explicit path by setting the {} environment variable", env)
-            ),
+            .ok_or_else(|| LoadError::HomeDirError {
+                env: env.to_string(),
+            }),
     }
 }

--- a/qcs/src/configuration/secrets.rs
+++ b/qcs/src/configuration/secrets.rs
@@ -6,7 +6,7 @@ use crate::configuration::LoadError;
 
 use super::path::path_from_env_or_home;
 
-/// Setting this environment variable will change which file is used for loading secrets
+/// Setting the `QCS_SECRETS_FILE_PATH` environment variable will change which file is used for loading secrets
 pub const SECRETS_PATH_VAR: &str = "QCS_SECRETS_FILE_PATH";
 
 pub(crate) async fn load() -> Result<Secrets, LoadError> {

--- a/qcs/src/configuration/settings.rs
+++ b/qcs/src/configuration/settings.rs
@@ -1,21 +1,23 @@
 use std::collections::HashMap;
 
-use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 
 use super::path::path_from_env_or_home;
+use super::LoadError;
 
 /// Setting this environment variable will change which file is used for loading settings
 pub const SETTINGS_PATH_VAR: &str = "QCS_SETTINGS_FILE_PATH";
 
-pub(crate) async fn load() -> Result<Settings> {
-    let path = path_from_env_or_home(SETTINGS_PATH_VAR, "settings.toml")
-        .wrap_err("When determining settings config path")?;
-    let content = tokio::fs::read_to_string(&path)
-        .await
-        .wrap_err_with(|| format!("When reading settings from {}", path.to_string_lossy()))?;
-    Ok(toml::from_str(&content)
-        .wrap_err_with(|| format!("When parsing settings from {}", path.to_string_lossy()))?)
+pub(crate) async fn load() -> Result<Settings, LoadError> {
+    let path = path_from_env_or_home(SETTINGS_PATH_VAR, "settings.toml")?;
+    let content =
+        tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|source| LoadError::FileOpenError {
+                path: path.clone(),
+                source,
+            })?;
+    toml::from_str(&content).map_err(|source| LoadError::FileParseError { path, source })
 }
 
 #[cfg(test)]

--- a/qcs/src/configuration/settings.rs
+++ b/qcs/src/configuration/settings.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::path::path_from_env_or_home;
 use super::LoadError;
 
-/// Setting this environment variable will change which file is used for loading settings
+/// Setting the `QCS_SETTINGS_FILE_PATH` environment variable will change which file is used for loading settings
 pub const SETTINGS_PATH_VAR: &str = "QCS_SETTINGS_FILE_PATH";
 
 pub(crate) async fn load() -> Result<Settings, LoadError> {

--- a/qcs/src/executable.rs
+++ b/qcs/src/executable.rs
@@ -464,7 +464,7 @@ impl From<qpu::ExecutionError> for Error {
             ExecutionError::Unauthorized => Self::Authentication,
             ExecutionError::QcsCommunication => Self::Connection(Service::Qcs),
             ExecutionError::Quil(message) => Self::Compilation(message),
-            ExecutionError::Bug(inner) => Self::Unexpected(format!("{:?}", inner)),
+            ExecutionError::Unexpected(inner) => Self::Unexpected(format!("{:?}", inner)),
             ExecutionError::Quilc { .. } => Self::Connection(Service::Quilc),
             ExecutionError::Qcs(message) => Self::Unexpected(message),
         }

--- a/qcs/src/executable.rs
+++ b/qcs/src/executable.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use eyre::{eyre, Report, Result, WrapErr};
-
-use crate::configuration::Configuration;
+use crate::configuration::{Configuration, LoadError, RefreshError};
+use crate::qpu::ExecutionError;
 use crate::{qpu, qvm, ExecutionResult};
 
 /// The builder interface for executing Quil programs on QVMs and QPUs.
@@ -247,20 +246,9 @@ impl Executable<'_, '_> {
     ///
     /// # Errors
     ///
-    /// All errors are returned in a human-readable format using [`mod@eyre`] since usually they aren't
-    /// recoverable at runtime and should just be logged for handling manually.
-    ///
-    /// ## QVM Connection Errors
-    ///
-    /// QVM must be running and accessible for this function to succeed. The address can be defined by
-    /// the `<profile>.applications.pyquil.qvm_url` setting in your QCS `settings.toml`. More info on
-    /// configuration [here][`crate::configuration`].
-    ///
-    /// ## Execution Errors
-    ///
-    /// A number of errors could occur if `program` is malformed.
+    /// See [`Error`].
     pub async fn execute_on_qvm(&mut self) -> ExecuteResult {
-        let config = self.get_config().await;
+        let config = self.get_config().await.unwrap_or_default();
         let mut qvm = if let Some(qvm) = self.qvm.take() {
             qvm
         } else {
@@ -274,22 +262,19 @@ impl Executable<'_, '_> {
     }
 
     /// Load `self.config` if not yet loaded, then return a reference to it.
-    async fn get_config(&mut self) -> Arc<Configuration> {
+    async fn get_config(&mut self) -> Result<Arc<Configuration>, Error> {
         if let Some(config) = &self.config {
-            config.clone()
+            Ok(config.clone())
         } else {
-            let config = Arc::new(Configuration::load().await.unwrap_or_else(|e| {
-                log::warn!("Got an error when loading config: {:#?}", e);
-                Configuration::default()
-            }));
+            let config = Arc::new(Configuration::load().await?);
             self.config = Some(config.clone());
-            config
+            Ok(config)
         }
     }
 
     /// Refresh `self.config` and return it.
-    async fn refresh_config(&mut self) -> Result<Arc<Configuration>> {
-        let config = self.get_config().await.as_ref().clone();
+    async fn refresh_config(&mut self) -> Result<Arc<Configuration>, Error> {
+        let config = self.get_config().await?.as_ref().clone();
         let refreshed = Arc::new(config.refresh().await?);
         self.config = Some(refreshed.clone());
         Ok(refreshed)
@@ -298,14 +283,17 @@ impl Executable<'_, '_> {
 
 impl<'execution> Executable<'_, 'execution> {
     /// Remove and return `self.qpu` if it's set and still valid. Otherwise, create a new one.
-    async fn qpu_for_id(&mut self, id: &'execution str) -> Result<qpu::Execution<'execution>> {
+    async fn qpu_for_id(
+        &mut self,
+        id: &'execution str,
+    ) -> Result<qpu::Execution<'execution>, Error> {
         if let Some(qpu) = self.qpu.take() {
             if qpu.quantum_processor_id == id && qpu.shots == self.shots {
                 return Ok(qpu);
             }
         }
-        let mut config = self.get_config().await;
-        let result = match qpu::Execution::new(
+        let mut config = self.get_config().await?;
+        match qpu::Execution::new(
             self.quil.clone(),
             self.shots,
             id,
@@ -314,12 +302,9 @@ impl<'execution> Executable<'_, 'execution> {
         )
         .await
         {
-            Ok(result) => Ok(result),
-            Err(qpu::Error::Qcs { .. }) => {
-                config = self
-                    .refresh_config()
-                    .await
-                    .wrap_err("When refreshing authentication token")?;
+            Ok(qpu) => Ok(qpu),
+            Err(ExecutionError::Unauthorized) => {
+                config = self.refresh_config().await?;
                 qpu::Execution::new(
                     self.quil.clone(),
                     self.shots,
@@ -328,10 +313,10 @@ impl<'execution> Executable<'_, 'execution> {
                     self.compile_with_quilc,
                 )
                 .await
+                .map_err(Error::from)
             }
-            err => err,
-        };
-        result.wrap_err_with(|| eyre!("When executing on {}", id))
+            Err(err) => Err(Error::from(err)),
+        }
     }
 
     /// Execute on a real QPU
@@ -362,46 +347,24 @@ impl<'execution> Executable<'_, 'execution> {
     /// [quilc]: https://github.com/quil-lang/quilc
     pub async fn execute_on_qpu(&mut self, quantum_processor_id: &'execution str) -> ExecuteResult {
         let mut qpu = self.qpu_for_id(quantum_processor_id).await?;
-        let mut config = self.get_config().await;
+        let mut config = self.get_config().await?;
 
         let response = match qpu.run(&self.params, self.get_readouts(), &config).await {
-            Ok(result) => Ok(result),
-            Err(qpu::Error::Qcs {
-                retry_after: None, ..
-            }) => {
-                // If retry_after is set, don't retry now
-                config = self
-                    .refresh_config()
-                    .await
-                    .wrap_err("When refreshing authentication token")?;
+            Ok(response) => Ok(response),
+            Err(ExecutionError::Unauthorized) => {
+                config = self.refresh_config().await?;
                 qpu.run(&self.params, self.get_readouts(), &config).await
             }
-            err => err,
+            Err(err) => Err(err),
         };
 
-        self.qpu = Some(qpu);
-        match response {
-            Ok(result) => Ok(result),
-            Err(qpu::Error::Qcs {
-                source,
-                retry_after,
-            }) => {
-                match retry_after {
-                    Some(duration) => {
-                        // retry_after could mean maintenance which requires recompile
-                        self.qpu = None;
-                        Err(Error::Retry {
-                            source,
-                            after: duration,
-                        })
-                    }
-                    None => Err(source.into()),
-                }
-            }
-            Err(quil_err @ qpu::Error::Quil { .. }) => Err(Error::from(
-                eyre!(quil_err).wrap_err("When compiling for the QPU"),
-            )),
-        }
+        self.qpu = if let Err(ExecutionError::QpuUnavailable(_)) = response {
+            // Could mean maintenance which requires recompile
+            None
+        } else {
+            Some(qpu)
+        };
+        response.map_err(Error::from)
     }
 }
 
@@ -409,17 +372,116 @@ impl<'execution> Executable<'_, 'execution> {
 /// [`Executable::execute_on_qvm`]..
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// An error that is due to a temporary problem and should be retried after `after` [`Duration`].
-    #[error("An error that is due to a temporary problem and should be retried.")]
-    Retry {
-        /// The error itself
-        source: Report,
-        /// The [`Duration`] to wait before retrying
-        after: Duration,
-    },
-    /// An error which is due to a permanent problem and should not be retried.
-    #[error("A fatal error that should not be retried.")]
-    Fatal(#[from] Report),
+    /// Communicating with QCS requires appropriate settings and secrets files. By default, these
+    /// should be `$HOME/.qcs/settings.toml` and `$HOME/.qcs/secrets.toml`, though those files can
+    /// be overridden by setting the `QCS_SETTINGS_FILE_PATH` and `QCS_SECRETS_FILE_PATH`
+    /// environment variables.
+    ///
+    /// This error can occur when one of those files is required but missing or there is a problem
+    /// with the contents of those files.
+    #[error("There was a problem related to your QCS settings: {0}")]
+    SettingsError(String),
+    /// This error occurs when the SDK was unable to authenticate a request to QCS. This could mean
+    /// that your credentials are invalid or expired, or that you do not have access to the requested
+    /// QPU.
+    #[error("Could not authenticate a request to QCS for the requested QPU.")]
+    AuthenticationError,
+    /// The requested QPU was not found. Either the QPU does not exist or you do not have access to it.
+    #[error("The requested QPU was not found.")]
+    QpuNotFound,
+    /// This happens when the QPU is down for maintenance and not accepting new jobs. If you receive
+    /// this error, internal compilation caches will have been cleared as programs should be recompiled
+    /// with new settings after a maintenance window. If you are mid-experiment, you might want to
+    /// start over.
+    #[error("QPU currently unavailable, retry after {} seconds", .0.as_secs())]
+    QpuUnavailable(Duration),
+    /// Indicates a problem connecting to an external service. Check your network connection and
+    /// ensure that any required local services (e.g., `qvm` or `quilc`) are running.
+    #[error("Error connecting to service {0:?}")]
+    Connection(Service),
+    /// There was some problem with the provided Quil program. This could be a syntax error with
+    /// quil, providing Quil-T to `quilc` or `qvm` (which is not supported), or forgetting to set
+    /// some parameters.
+    #[error("There was a problem compiling the Quil program: {0}")]
+    CompilationError(String),
+    /// This error returns when a runtime check that _should_ always pass fails. This most likely
+    /// indicates a bug in the SDK and should be reported to
+    /// [GitHub](https://github.com/rigetti/qcs-sdk-rust/issues),
+    #[error("An unexpected error occurred, please open an issue on GitHub: {0:?}")]
+    Unexpected(String),
+}
+
+#[derive(Debug)]
+/// The external services that this SDK may connect to. Used to differentiate between networking
+/// issues in [`Error::Connection`].
+pub enum Service {
+    /// The open source [`quilc`](https://github.com/quil-lang/quilc) compiler.
+    ///
+    /// This compiler must be running before calling [`Executable::execute_on_qpu`] unless the
+    /// [`Executable::compile_with_quilc`] option is set to `false`. By default, it's assumed that
+    /// this is running on `tcp://localhost:5555`, but this can be overridden via
+    /// `[profiles.<profile_name>.applications.pyquil.quilc_url]` in your `.qcs/settings.toml` file.
+    Quilc,
+    /// The open source [`qvm`](https://github.com/quil-lang/qvm) simulator.
+    ///
+    /// This simulator must be running before calling [`Executable::execute_on_qvm`]. By default,
+    /// it's assumed that this is running on `http://localhost:5000`, but this can be overridden via
+    /// `[profiles.<profile_name>.applications.pyquil.qvm_url]` in your `.qcs/settings.toml` file.
+    Qvm,
+    /// The connection to [`QCS`](https://docs.rigetti.com/qcs/), the API for authentication,
+    /// QPU lookup, and translation.
+    ///
+    /// You should be able to reach this service as long as you have a connection to the internet.
+    Qcs,
+    /// The connection to the QPU itself. You can only connect to the QPU from an authorized network
+    /// (like QCS JupyterLab).
+    Qpu,
+}
+
+impl From<LoadError> for Error {
+    fn from(err: LoadError) -> Self {
+        Self::SettingsError(format!("{}", err))
+    }
+}
+
+impl From<RefreshError> for Error {
+    fn from(err: RefreshError) -> Self {
+        match err {
+            RefreshError::NoRefreshToken => Self::SettingsError(String::from(
+                "No `refresh_token` was found in your QCS secrets file for the selected profile. \
+                    You can change profiles with the `QCS_PROFILE_NAME` environment variable.",
+            )),
+            RefreshError::FetchError(_) => Self::AuthenticationError,
+        }
+    }
+}
+
+impl From<qpu::ExecutionError> for Error {
+    fn from(err: ExecutionError) -> Self {
+        match err {
+            ExecutionError::QpuNotFound => Self::QpuNotFound,
+            ExecutionError::QpuUnavailable(duration) => Self::QpuUnavailable(duration),
+            ExecutionError::Unauthorized => Self::AuthenticationError,
+            ExecutionError::QcsCommunication => Self::Connection(Service::Qcs),
+            ExecutionError::Quil(message) => Self::CompilationError(message),
+            ExecutionError::Bug(inner) => Self::Unexpected(format!("{:?}", inner)),
+            ExecutionError::Quilc { .. } => Self::Connection(Service::Quilc),
+            ExecutionError::Qcs(message) => Self::Unexpected(message),
+        }
+    }
+}
+
+impl From<qvm::Error> for Error {
+    fn from(err: qvm::Error) -> Self {
+        match err {
+            qvm::Error::QvmCommunication { .. } => Self::Connection(Service::Qvm),
+            qvm::Error::Parsing(_)
+            | qvm::Error::ShotsMustBePositive
+            | qvm::Error::RegionSizeMismatch { .. }
+            | qvm::Error::RegionNotFound { .. }
+            | qvm::Error::Qvm { .. } => Self::CompilationError(format!("{}", err)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -431,7 +493,7 @@ mod describe_qpu_for_id {
     async fn it_refreshes_auth_token() {
         let mut exe = Executable::from_quil("");
         // Default config has no auth, so it should try to refresh
-        exe.config = Some(Configuration::default());
+        exe.config = Some(Arc::new(Configuration::default()));
         let result = exe.qpu_for_id("blah").await;
         let err = if let Err(err) = result {
             err
@@ -449,17 +511,17 @@ mod describe_qpu_for_id {
         exe.shots = shots;
         exe.qpu = Some(
             qpu::Execution::new(
-                "",
+                "".into(),
                 shots,
                 "Aspen-9",
-                &exe.take_or_load_config().await,
+                exe.get_config().await.unwrap_or_default(),
                 exe.compile_with_quilc,
             )
             .await
             .unwrap(),
         );
         // Load config with no credentials to prevent creating a new Execution if it tries
-        exe.config = Some(Configuration::default());
+        exe.config = Some(Arc::new(Configuration::default()));
 
         assert!(exe.qpu_for_id("Aspen-9").await.is_ok());
     }
@@ -491,7 +553,7 @@ mod describe_qpu_for_id {
         // Cache so we can verify cache is not used.
         exe.qpu = Some(qpu);
         // Load config with no credentials to prevent creating the new Execution (which would fail anyway)
-        exe.config = Some(Configuration::default());
+        exe.config = Some(Arc::new(Configuration::default()));
         let result = exe.qpu_for_id("Aspen-8").await;
 
         assert!(matches!(result, Err(_)));
@@ -507,7 +569,7 @@ mod describe_take_or_load_config {
     #[tokio::test]
     async fn it_returns_cached_values() {
         let mut exe = Executable::from_quil("");
-        let mut config = Configuration::default();
+        let mut config = Arc::new(Configuration::default());
         config.quilc_url = String::from("test");
         exe.config = Some(config.clone());
         let gotten = exe.take_or_load_config().await;

--- a/qcs/src/lib.rs
+++ b/qcs/src/lib.rs
@@ -9,7 +9,7 @@
 //! crate allows you to run Quil programs against real QPUs or a QVM
 //! using [`Executable`].
 
-pub use executable::{Error, Executable};
+pub use executable::{Error, Executable, Service};
 pub use execution_result::ExecutionResult;
 
 pub mod configuration;

--- a/qcs/src/qpu/engagement.rs
+++ b/qcs/src/qpu/engagement.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use eyre::{eyre, Report, Result, WrapErr};
 use reqwest::StatusCode;
 
 use qcs_api::apis::configuration::Configuration as ApiConfig;
@@ -38,8 +37,7 @@ async fn create_engagement(
     let local_var_client = &local_var_configuration.client;
 
     let local_var_uri_str = format!("{}/v1/engagements", local_var_configuration.base_path);
-    let mut local_var_req_builder =
-        local_var_client.request(reqwest::Method::POST, local_var_uri_str.as_str());
+    let mut local_var_req_builder = local_var_client.post(local_var_uri_str.as_str());
 
     if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
         local_var_req_builder =
@@ -50,13 +48,11 @@ async fn create_engagement(
     };
     local_var_req_builder = local_var_req_builder.json(&create_engagement_request);
 
-    let local_var_req = local_var_req_builder
-        .build()
-        .wrap_err("Failed to build request")?;
+    let local_var_req = local_var_req_builder.build().map_err(Error::Internal)?;
     let local_var_resp = local_var_client
         .execute(local_var_req)
         .await
-        .wrap_err("Failed to send request to QCS")?;
+        .map_err(Error::Connection)?;
 
     let local_var_status = local_var_resp.status();
 
@@ -64,33 +60,39 @@ async fn create_engagement(
         local_var_resp
             .json::<EngagementWithCredentials>()
             .await
-            .wrap_err("Response is not a valid JSON")
-            .map_err(Error::from)
+            .map_err(Error::Schema)
     } else if local_var_status == StatusCode::SERVICE_UNAVAILABLE {
-        let seconds = local_var_resp
+        let retry_after = local_var_resp
             .headers()
             .get(reqwest::header::RETRY_AFTER)
-            .ok_or_else(|| eyre!("Service is unavailable but no Retry-After is specified"))?
-            .to_str()
-            .wrap_err("Failed to parse Retry-After header")?
-            .parse::<u64>()
-            .wrap_err("Failed to parse Retry-After header")?;
-        Err(Error::QuantumProcessorUnavailable(Duration::from_secs(
-            seconds,
-        )))
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<u64>().ok())
+            .map_or(DEFAULT_RETRY_AFTER, Duration::from_secs);
+        Err(Error::QuantumProcessorUnavailable(retry_after))
+    } else if local_var_status == StatusCode::UNAUTHORIZED
+        || local_var_status == StatusCode::FORBIDDEN
+    {
+        Err(Error::Unauthorized)
     } else {
-        let local_var_entity: ErrorPayload =
-            local_var_resp.json().await.wrap_err("Cannot parse error")?;
-        Err(Error::Authorization(local_var_entity))
+        let local_var_entity: ErrorPayload = local_var_resp.json().await.map_err(Error::Schema)?;
+        Err(Error::Unknown(local_var_entity))
     }
 }
 
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(15 /* minutes */ * 60);
+
 #[derive(thiserror::Error, Debug)]
 pub(super) enum Error {
-    #[error("the QPU is unavailable, try again after {}", .0.as_secs())]
+    #[error("the QPU is unavailable, try again after {} seconds", .0.as_secs())]
     QuantumProcessorUnavailable(Duration),
-    #[error("error gathering QPU authorization")]
-    Authorization(ErrorPayload),
-    #[error(transparent)]
-    General(#[from] Report),
+    #[error("Received an unauthorized response, try refreshing the token")]
+    Unauthorized,
+    #[error("Could not understand a response from QCS, this is likely a bug in this library")]
+    Schema(#[source] reqwest::Error),
+    #[error("Received an unknown error from QCS: {}", .0.message)]
+    Unknown(ErrorPayload),
+    #[error("A bug in this library prevented the request from being sent")]
+    Internal(#[source] reqwest::Error),
+    #[error("Trouble connecting to QCS, check your network connection")]
+    Connection(#[source] reqwest::Error),
 }

--- a/qcs/src/qpu/rpcq.rs
+++ b/qcs/src/qpu/rpcq.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use eyre::{eyre, Result, WrapErr};
 use rmp_serde::Serializer;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zmq::{Context, Socket, SocketType};
+
+use crate::qpu::rpcq::Error::AuthSetup;
 
 /// A minimal RPCQ client that does just enough to talk to `quilc` and QPU endpoints
 pub(crate) struct Client {
@@ -14,33 +15,32 @@ pub(crate) struct Client {
 
 impl Client {
     /// Construct a new [`Client`] with no authentication configured.
-    pub(crate) fn new(endpoint: &str) -> Result<Self> {
+    pub(crate) fn new(endpoint: &str) -> Result<Self, Error> {
         let socket = Context::new()
             .socket(SocketType::DEALER)
-            .wrap_err("Could not create a socket")?;
-        socket
-            .connect(endpoint)
-            .wrap_err("Could not connect to ZMQ endpoint")?;
+            .map_err(Error::SocketCreation)?;
+        socket.connect(endpoint).map_err(Error::Communication)?;
         Ok(Self { socket })
     }
 
     /// Construct a new [`Client`] with authentication.
-    pub(crate) fn new_with_credentials(endpoint: &str, credentials: &Credentials) -> Result<Self> {
+    pub(crate) fn new_with_credentials(
+        endpoint: &str,
+        credentials: &Credentials,
+    ) -> Result<Self, Error> {
         let socket = Context::new()
             .socket(SocketType::DEALER)
-            .wrap_err("Could not create a socket")?;
+            .map_err(Error::SocketCreation)?;
         socket
             .set_curve_publickey(credentials.client_public_key.as_bytes())
-            .wrap_err("Could not set public key")?;
+            .map_err(AuthSetup)?;
         socket
             .set_curve_secretkey(credentials.client_secret_key.as_bytes())
-            .wrap_err("Could not set private key")?;
+            .map_err(AuthSetup)?;
         socket
             .set_curve_serverkey(credentials.server_public_key.as_bytes())
-            .wrap_err("Could not set server public key")?;
-        socket
-            .connect(endpoint)
-            .wrap_err("Could not connect to ZMQ endpoint")?;
+            .map_err(AuthSetup)?;
+        socket.connect(endpoint).map_err(Error::Communication)?;
         Ok(Self { socket })
     }
 
@@ -52,8 +52,8 @@ impl Client {
     pub(crate) fn run_request<Request: Serialize, Response: DeserializeOwned>(
         &self,
         request: &RPCRequest<Request>,
-    ) -> Result<Response> {
-        self.send(request).wrap_err("Could not send request")?;
+    ) -> Result<Response, Error> {
+        self.send(request)?;
         self.receive::<Response>(&request.id)
     }
 
@@ -62,46 +62,62 @@ impl Client {
     /// # Arguments
     ///
     /// * `request`: An [`RPCRequest`] containing some params.
-    pub(crate) fn send<Request: Serialize>(&self, request: &RPCRequest<Request>) -> Result<()> {
+    pub(crate) fn send<Request: Serialize>(
+        &self,
+        request: &RPCRequest<Request>,
+    ) -> Result<(), Error> {
         let mut data = vec![];
         request
             .serialize(&mut Serializer::new(&mut data).with_struct_map())
-            .wrap_err("Could not serialize request as MessagePack")?;
+            .map_err(Error::Serialization)?;
 
-        self.socket
-            .send(data, 0)
-            .wrap_err("Could not send request to ZMQ server")
+        self.socket.send(data, 0).map_err(Error::Communication)
     }
 
     /// Retrieve and decode a response
     ///
     /// returns: Result<Response, Error> where Response is a generic type that implements
     /// [`DeserializeOwned`] (meaning [`Deserialize`] with no lifetimes).
-    fn receive<Response: DeserializeOwned>(&self, request_id: &str) -> Result<Response> {
+    fn receive<Response: DeserializeOwned>(&self, request_id: &str) -> Result<Response, Error> {
         let data = self.receive_raw()?;
 
-        let reply: RPCResponse<Response> = rmp_serde::from_read(data.as_slice())
-            .wrap_err("Could not decode ZMQ server's response")?;
+        let reply: RPCResponse<Response> =
+            rmp_serde::from_read(data.as_slice()).map_err(Error::Deserialization)?;
         match reply {
             RPCResponse::RPCReply { id, result } => {
                 if id == request_id {
                     Ok(result)
                 } else {
-                    Err(eyre!("Response ID did not match request ID"))
+                    Err(Error::ResponseIdMismatch)
                 }
             }
-            RPCResponse::RPCError { error, .. } => {
-                Err(eyre!("Received error message from server: {}", error))
-            }
+            RPCResponse::RPCError { error, .. } => Err(Error::Response(error)),
         }
     }
 
     /// Retrieve the raw bytes of a response
-    pub(crate) fn receive_raw(&self) -> Result<Vec<u8>> {
-        self.socket
-            .recv_bytes(0)
-            .wrap_err("Could not receive data from ZMQ server")
+    pub(crate) fn receive_raw(&self) -> Result<Vec<u8>, Error> {
+        self.socket.recv_bytes(0).map_err(Error::Communication)
     }
+}
+
+/// All of the possible errors for this module
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("Could not create a socket.")]
+    SocketCreation(#[source] zmq::Error),
+    #[error("Failed while trying to set up auth. This is likely a bug in this library.")]
+    AuthSetup(#[source] zmq::Error),
+    #[error("Trouble communicating with the ZMQ server")]
+    Communication(#[source] zmq::Error),
+    #[error("Could not serialize request as MessagePack. This is a bug in this library.")]
+    Serialization(#[from] rmp_serde::encode::Error),
+    #[error("Could not decode ZMQ server's response. This is likely a bug in this library.")]
+    Deserialization(#[from] rmp_serde::decode::Error),
+    #[error("Response ID did not match request ID")]
+    ResponseIdMismatch,
+    #[error("Received error message from server: {0}")]
+    Response(String),
 }
 
 /// A single request object according to the JSONRPC standard.

--- a/qcs/src/qpu/runner.rs
+++ b/qcs/src/qpu/runner.rs
@@ -55,8 +55,8 @@ pub(crate) fn execute(
 pub(crate) enum Error {
     #[error("Error connecting to the QPU")]
     Connection(#[source] RPCQError),
-    #[error("A bug in this library")]
-    Bug(#[source] RPCQError),
+    #[error("An error not expected to occur—if encountered it may indicate bug in this library")]
+    Unexpected(#[source] RPCQError),
     #[error("An error was returned from the QPU: {0}")]
     Qpu(String),
 }
@@ -69,7 +69,7 @@ impl From<RPCQError> for Error {
             | RPCQError::ResponseIdMismatch => Self::Connection(err),
             RPCQError::AuthSetup(_)
             | RPCQError::Serialization(_)
-            | RPCQError::Deserialization(_) => Self::Bug(err),
+            | RPCQError::Deserialization(_) => Self::Unexpected(err),
             RPCQError::Response(message) => Self::Qpu(message),
         }
     }

--- a/qcs/src/qpu/runner.rs
+++ b/qcs/src/qpu/runner.rs
@@ -3,7 +3,6 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
 
 use enum_as_inner::EnumAsInner;
-use eyre::{eyre, Result, WrapErr};
 use log::{debug, trace, warn};
 use num::complex::Complex32;
 use serde::{Deserialize, Serialize};
@@ -13,13 +12,14 @@ use qcs_api::models::EngagementWithCredentials;
 
 use crate::executable::Parameters;
 
-use super::rpcq::{Client, Credentials, RPCRequest};
+use super::rpcq::{Client, Credentials, Error as RPCQError, RPCRequest};
 
+/// Execute compiled program on a QPU.
 pub(crate) fn execute(
     program: &str,
     engagement: &EngagementWithCredentials,
     patch_values: &Parameters,
-) -> Result<HashMap<String, Buffer>> {
+) -> Result<HashMap<String, Buffer>, Error> {
     let params = QPUParams::from_program(program, patch_values);
     let EngagementWithCredentials {
         address,
@@ -30,7 +30,7 @@ pub(crate) fn execute(
     // This is a hack to allow testing without credentials since ZAP is absurd
     let client = if credentials.server_public.is_empty() {
         warn!("Connecting to QPU on {} with no credentials.", address);
-        Client::new(address).wrap_err("Unable to connect to the QPU")?
+        Client::new(address)?
     } else {
         let credentials = Credentials {
             client_secret_key: &credentials.client_secret,
@@ -38,19 +38,41 @@ pub(crate) fn execute(
             server_public_key: &credentials.server_public,
         };
         trace!("Connecting to QPU at {} with credentials", &address);
-        Client::new_with_credentials(address, &credentials)
-            .wrap_err("Unable to connect to the QPU")?
+        Client::new_with_credentials(address, &credentials)?
     };
 
     let request = RPCRequest::from(&params);
-    let job_id: String = client
-        .run_request(&request)
-        .wrap_err("While attempting to send the program to the QPU")?;
+    let job_id: String = client.run_request(&request)?;
     debug!("Received job ID {} from QPU", &job_id);
     let get_buffers_request = GetBuffersRequest::new(job_id);
     client
         .run_request(&RPCRequest::from(&get_buffers_request))
-        .wrap_err("While attempting to receive results from the QPU")
+        .map_err(Error::from)
+}
+
+/// All of the possible errors for this module
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("Error connecting to the QPU")]
+    Connection(#[source] RPCQError),
+    #[error("A bug in this library")]
+    Bug(#[source] RPCQError),
+    #[error("An error was returned from the QPU: {0}")]
+    Qpu(String),
+}
+
+impl From<RPCQError> for Error {
+    fn from(err: RPCQError) -> Self {
+        match err {
+            RPCQError::SocketCreation(_)
+            | RPCQError::Communication(_)
+            | RPCQError::ResponseIdMismatch => Self::Connection(err),
+            RPCQError::AuthSetup(_)
+            | RPCQError::Serialization(_)
+            | RPCQError::Deserialization(_) => Self::Bug(err),
+            RPCQError::Response(message) => Self::Qpu(message),
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -141,23 +163,36 @@ impl Display for DataType {
     }
 }
 
+/// Errors that can occur when decoding the results from the QPU
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DecodeError {
+    #[error("Only 1-dimensional buffer shapes are currently supported")]
+    InvalidShape,
+    #[error("Expected buffer length {expected}, got {actual}")]
+    BufferLength { expected: usize, actual: usize },
+    #[error("Missing expected buffer named {0}, did you forget to MEASURE?")]
+    MissingBuffer(String),
+    #[error("This SDK expects contiguous memory, but {register}[{index}] was missing.")]
+    ContiguousMemory { register: String, index: usize },
+    #[error("A single register should have the same type for all shots, got mixed types.")]
+    MixedTypes,
+}
+
 impl Buffer {
-    fn check_shape(&self) -> eyre::Result<()> {
+    fn check_shape(&self) -> Result<(), DecodeError> {
         if self.shape.len() == 1 {
             Ok(())
         } else {
-            Err(eyre!(
-                "Only 1-dimensional buffer shapes are currently supported"
-            ))
+            Err(DecodeError::InvalidShape)
         }
     }
 
-    fn assert_len(&self, expected: usize) -> eyre::Result<()> {
+    fn assert_len(&self, expected: usize) -> Result<(), DecodeError> {
         let actual = self.data.len();
         if expected == actual {
             Ok(())
         } else {
-            Err(eyre!("Expected buffer length {}, got {}", expected, actual,))
+            Err(DecodeError::BufferLength { expected, actual })
         }
     }
 }
@@ -178,7 +213,7 @@ pub(crate) enum Register {
 
 #[allow(clippy::cast_possible_wrap)]
 impl TryFrom<Buffer> for Register {
-    type Error = eyre::Error;
+    type Error = DecodeError;
 
     fn try_from(buffer: Buffer) -> Result<Register, Self::Error> {
         const NUM_BYTES_IN_F64: usize = 8;

--- a/qcs/src/qpu/translation.rs
+++ b/qcs/src/qpu/translation.rs
@@ -1,20 +1,24 @@
-use eyre::{Result, WrapErr};
+use reqwest::StatusCode;
 
 use qcs_api::apis::translation_api as translation;
+use qcs_api::apis::translation_api::TranslateNativeQuilToEncryptedBinaryError;
+use qcs_api::apis::Error as UntypedApiError;
 use qcs_api::models::{
-    TranslateNativeQuilToEncryptedBinaryRequest, TranslateNativeQuilToEncryptedBinaryResponse,
+    Error as QcsError, TranslateNativeQuilToEncryptedBinaryRequest,
+    TranslateNativeQuilToEncryptedBinaryResponse,
 };
 
 use crate::configuration::Configuration;
-
 use crate::qpu::rewrite_arithmetic::RewrittenQuil;
+
+type ApiError = UntypedApiError<TranslateNativeQuilToEncryptedBinaryError>;
 
 pub(crate) async fn translate(
     quil: RewrittenQuil,
     shots: u16,
     quantum_processor_id: &str,
     config: &Configuration,
-) -> Result<TranslateNativeQuilToEncryptedBinaryResponse> {
+) -> Result<TranslateNativeQuilToEncryptedBinaryResponse, Error> {
     let translation_request = TranslateNativeQuilToEncryptedBinaryRequest {
         num_shots: shots.into(),
         quil: quil.into(),
@@ -26,5 +30,46 @@ pub(crate) async fn translate(
         translation_request,
     )
     .await
-    .wrap_err("While translating native quil to binary")
+    .map_err(Error::from)
+}
+
+/// Errors that can occur during Translation
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error("Provided program could not be translated: {}", .0.message)]
+    ProgramIssue(QcsError),
+    #[error("Problem connecting to QCS")]
+    Connection(#[source] ApiError),
+    #[error("Serialization failed, this is likely a bug in this library")]
+    SerializationBug(#[from] serde_json::Error),
+    #[error("Unauthorized request")]
+    Unauthorized,
+    #[error("An unknown error occurred, this is likely a bug in this library: {0}")]
+    Unknown(String),
+}
+
+impl From<ApiError> for Error {
+    fn from(error: ApiError) -> Self {
+        match error {
+            ApiError::Reqwest(_) | ApiError::Io(_) => Self::Connection(error),
+            ApiError::Serde(inner) => inner.into(),
+            ApiError::ResponseError(inner) => {
+                if matches!(
+                    inner.status,
+                    StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+                ) {
+                    Self::Unauthorized
+                } else {
+                    match inner.entity {
+                        Some(TranslateNativeQuilToEncryptedBinaryError::Status400(detail))
+                            if inner.status == StatusCode::BAD_REQUEST =>
+                        {
+                            Self::ProgramIssue(detail)
+                        }
+                        _ => Self::Unknown(inner.content),
+                    }
+                }
+            }
+        }
+    }
 }

--- a/qcs/src/qpu/translation.rs
+++ b/qcs/src/qpu/translation.rs
@@ -41,7 +41,7 @@ pub(crate) enum Error {
     #[error("Problem connecting to QCS")]
     Connection(#[source] ApiError),
     #[error("Serialization failed, this is likely a bug in this library")]
-    SerializationBug(#[from] serde_json::Error),
+    Serialization(#[from] serde_json::Error),
     #[error("Unauthorized request")]
     Unauthorized,
     #[error("An unknown error occurred, this is likely a bug in this library: {0}")]


### PR DESCRIPTION
Closes #62 

BREAKING CHANGE: Changed the error types returned from all public methods.