### PR TITLE
feat!: Return billable QPU execution time in results.

### DIFF
--- a/qcs/examples/parametric_compilation.rs
+++ b/qcs/examples/parametric_compilation.rs
@@ -2,6 +2,7 @@
 //! [pyquil]: https://pyquil-docs.rigetti.com/en/stable/basics.html?highlight=parametric#parametric-compilation
 
 use std::f64::consts::PI;
+use std::time::Duration;
 
 use qcs::Executable;
 
@@ -22,18 +23,23 @@ async fn main() {
     let mut parametric_measurements = Vec::with_capacity(200);
 
     let step = 2.0 * PI / 50.0;
+    let mut total_execution_time = Duration::new(0, 0);
 
     for i in 0..=50 {
         let theta = step * f64::from(i);
-        let result = exe
+        let mut data = exe
             .with_parameter("theta", 0, theta)
             .execute_on_qpu("Aspen-11")
             .await
-            .expect("Failed to execute")
-            .remove("ro")
-            .expect("Missing ro register");
+            .expect("Failed to execute");
+        total_execution_time += data
+            .duration
+            .expect("Aspen-11 should always report duration");
+        let result = data.registers.remove("ro").expect("Missing ro register");
         parametric_measurements.append(&mut result.into_i16().unwrap()[0])
     }
+
+    println!("Total execution time: {:?}", total_execution_time);
 
     for measurement in parametric_measurements {
         if measurement == 1 {

--- a/qcs/examples/quil_t.rs
+++ b/qcs/examples/quil_t.rs
@@ -22,6 +22,7 @@ async fn main() {
         .execute_on_qpu("Aspen-11")
         .await
         .expect("Failed to execute")
+        .registers
         .remove("ro")
         .expect("Missing ro register");
 

--- a/qcs/src/execution_data.rs
+++ b/qcs/src/execution_data.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::RegisterData;
+
+/// The result of executing an [`Executable`][crate::Executable] via
+/// [`Executable::execute_on_qvm`][crate::Executable::execute_on_qvm] or
+/// [`Executable::execute_on_qpu`][crate::Executable::execute_on_qpu].
+pub struct ExecutionData {
+    /// The data of all registers that were read from
+    /// (via [`Executable::read_from`][crate::Executable::read_from]). Key is the name of the
+    /// register, value is the data of the register after execution.
+    pub registers: HashMap<Box<str>, RegisterData>,
+    /// The time it took to execute the program on the QPU, not including any network or queueing
+    /// time. If paying for on-demand execution, this is the amount you will be billed for.
+    ///
+    /// This will always be `None` for QVM execution.
+    pub duration: Option<Duration>,
+}

--- a/qcs/src/lib.rs
+++ b/qcs/src/lib.rs
@@ -10,10 +10,12 @@
 //! using [`Executable`].
 
 pub use executable::{Error, Executable, Service};
-pub use execution_result::ExecutionResult;
+pub use execution_data::ExecutionData;
+pub use register_data::RegisterData;
 
 pub mod configuration;
 mod executable;
-mod execution_result;
+mod execution_data;
 mod qpu;
 mod qvm;
+mod register_data;

--- a/qcs/src/qvm/execution.rs
+++ b/qcs/src/qvm/execution.rs
@@ -8,7 +8,7 @@ use quil_rs::{
 
 use crate::configuration::Configuration;
 use crate::executable::Parameters;
-use crate::ExecutionResult;
+use crate::RegisterData;
 
 use super::{Request, Response};
 
@@ -59,7 +59,7 @@ impl Execution {
         readouts: &[&str],
         params: &Parameters,
         config: &Configuration,
-    ) -> Result<HashMap<Box<str>, ExecutionResult>, Error> {
+    ) -> Result<HashMap<Box<str>, RegisterData>, Error> {
         if shots == 0 {
             return Err(Error::ShotsMustBePositive);
         }
@@ -108,7 +108,7 @@ impl Execution {
         shots: u16,
         readouts: &[&str],
         config: &Configuration,
-    ) -> Result<HashMap<Box<str>, ExecutionResult>, Error> {
+    ) -> Result<HashMap<Box<str>, RegisterData>, Error> {
         let request = Request::new(&self.program.to_string(true), shots, readouts);
 
         let client = reqwest::Client::new();

--- a/qcs/src/qvm/mod.rs
+++ b/qcs/src/qvm/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) use execution::{Error, Execution};
 
-use crate::ExecutionResult;
+use crate::RegisterData;
 
 mod execution;
 
@@ -21,7 +21,7 @@ pub(super) enum Response {
 #[derive(Debug, Deserialize)]
 pub(super) struct Success {
     #[serde(flatten)]
-    pub registers: HashMap<String, ExecutionResult>,
+    pub registers: HashMap<String, RegisterData>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/qcs/src/register_data.rs
+++ b/qcs/src/register_data.rs
@@ -24,7 +24,7 @@ use crate::qpu::{DecodeError, Register};
 /// convert any variant type to its inner data.
 #[derive(Debug, Deserialize, EnumAsInner, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum ExecutionResult {
+pub enum RegisterData {
     /// Corresponds to the Quil `BIT` or `OCTET` types.
     I8(Vec<Vec<i8>>),
     /// Corresponds to the Quil `REAL` type.
@@ -36,7 +36,7 @@ pub enum ExecutionResult {
     Complex32(Vec<Vec<Complex32>>),
 }
 
-impl ExecutionResult {
+impl RegisterData {
     pub(crate) fn try_from_registers(
         registers_by_name: HashMap<Box<str>, Vec<Register>>,
         shots: u16,
@@ -135,9 +135,9 @@ mod describe_program_results {
         let registers = hashmap! {
             Box::from(String::from("ro")) => vec![Register::I8(vec![1, 2, 3]), Register::I8(vec![4, 5, 6])]
         };
-        let results = ExecutionResult::try_from_registers(registers, 3).unwrap();
+        let results = RegisterData::try_from_registers(registers, 3).unwrap();
         let expected = hashmap! {
-            Box::from(String::from("ro")) => ExecutionResult::I8(vec![vec![1, 4], vec![2, 5], vec![3, 6]])
+            Box::from(String::from("ro")) => RegisterData::I8(vec![vec![1, 4], vec![2, 5], vec![3, 6]])
         };
         assert_eq!(results, expected);
     }
@@ -147,9 +147,9 @@ mod describe_program_results {
         let registers = hashmap! {
             Box::from(String::from("ro")) => vec![Register::I16(vec![1, 2, 3]), Register::I16(vec![4, 5, 6])]
         };
-        let results = ExecutionResult::try_from_registers(registers, 3).unwrap();
+        let results = RegisterData::try_from_registers(registers, 3).unwrap();
         let expected = hashmap! {
-            Box::from(String::from("ro")) => ExecutionResult::I16(vec![vec![1, 4], vec![2, 5], vec![3, 6]])
+            Box::from(String::from("ro")) => RegisterData::I16(vec![vec![1, 4], vec![2, 5], vec![3, 6]])
         };
         assert_eq!(results, expected);
     }
@@ -162,9 +162,9 @@ mod describe_program_results {
                 Register::F64(vec![4.0, 5.0, 6.0]),
             ]
         };
-        let results = ExecutionResult::try_from_registers(registers, 3).unwrap();
+        let results = RegisterData::try_from_registers(registers, 3).unwrap();
         let expected = hashmap! {
-            Box::from(String::from("ro")) => ExecutionResult::F64(vec![vec![1.0, 4.0], vec![2.0, 5.0], vec![3.0, 6.0]])
+            Box::from(String::from("ro")) => RegisterData::F64(vec![vec![1.0, 4.0], vec![2.0, 5.0], vec![3.0, 6.0]])
         };
         assert_eq!(results, expected);
     }
@@ -185,9 +185,9 @@ mod describe_program_results {
                 ]),
             ]
         };
-        let results = ExecutionResult::try_from_registers(registers, 3).unwrap();
+        let results = RegisterData::try_from_registers(registers, 3).unwrap();
         let expected = hashmap! {
-            Box::from(String::from("ro")) => ExecutionResult::Complex32(vec![
+            Box::from(String::from("ro")) => RegisterData::Complex32(vec![
                 vec![Complex32::from(1.0), Complex32::from(4.0)],
                 vec![Complex32::from(2.0), Complex32::from(5.0)],
                 vec![Complex32::from(3.0), Complex32::from(6.0)],
@@ -201,7 +201,7 @@ mod describe_program_results {
         let registers = hashmap! {
             Box::from(String::from("ro")) => vec![Register::I8(vec![1, 2, 3]), Register::I16(vec![4, 5, 6])]
         };
-        let results = ExecutionResult::try_from_registers(registers, 3);
+        let results = RegisterData::try_from_registers(registers, 3);
         assert!(results.is_err());
     }
 
@@ -211,10 +211,10 @@ mod describe_program_results {
             Box::from(String::from("first")) => vec![Register::I8(vec![1, 2, 3]), Register::I8(vec![4, 5, 6])],
             Box::from(String::from("second")) => vec![Register::I16(vec![1, 2, 3]), Register::I16(vec![4, 5, 6])],
         };
-        let results = ExecutionResult::try_from_registers(registers, 3).unwrap();
+        let results = RegisterData::try_from_registers(registers, 3).unwrap();
         let expected = hashmap! {
-            Box::from(String::from("first")) => ExecutionResult::I8(vec![vec![1, 4], vec![2, 5], vec![3, 6]]),
-            Box::from(String::from("second")) => ExecutionResult::I16(vec![vec![1, 4], vec![2, 5], vec![3, 6]]),
+            Box::from(String::from("first")) => RegisterData::I8(vec![vec![1, 4], vec![2, 5], vec![3, 6]]),
+            Box::from(String::from("second")) => RegisterData::I16(vec![vec![1, 4], vec![2, 5], vec![3, 6]]),
         };
         assert_eq!(results, expected);
     }

--- a/qcs/tests/basic_qvm.rs
+++ b/qcs/tests/basic_qvm.rs
@@ -27,11 +27,13 @@ async fn test_bell_state() {
         .expect("Could not run on QVM");
 
     let first: Vec<Vec<i8>> = data
+        .registers
         .remove("first")
         .expect("Missing first buffer")
         .into_i8()
         .expect("Produced wrong data type");
     let second: Vec<Vec<i8>> = data
+        .registers
         .remove("second")
         .expect("Missing second buffer")
         .into_i8()

--- a/qcs/tests/parametric_compilation.rs
+++ b/qcs/tests/parametric_compilation.rs
@@ -32,6 +32,7 @@ async fn basic_substitution() {
             .expect("Failed to execute");
         parametric_measurements.append(
             &mut result
+                .registers
                 .remove("ro")
                 .expect("Missing ro register")
                 .into_i8()


### PR DESCRIPTION
BREAKING CHANGE: The return type of `Executable::execute_on_qpu` and `Executable::execute_on_qvm` is a new `ExecutionData` struct. The previous result map is now stored on `ExecutionData::registers` with the renamed `RegisterData` type (previously `ExecutionResult`).

Closes #89