### PR TITLE
feat: export JobHandle and derive traits on it

### DIFF
--- a/src/executable.rs
+++ b/src/executable.rs
@@ -529,6 +529,7 @@ impl From<qvm::Error> for Error {
 
 /// The result of calling [`Executable::submit_to_qpu`]. Represents a quantum program running on
 /// a QPU. Can be passed to [`Executable::retrieve_results`] to retrieve the results of the job.
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct JobHandle<'executable> {
     job_id: JobId,
     quantum_processor_id: &'executable str,
@@ -536,6 +537,7 @@ pub struct JobHandle<'executable> {
 
 impl JobHandle<'_> {
     /// The string representation of the QCS Job ID. Useful for debugging.
+    #[must_use]
     pub fn job_id(&self) -> &str {
         self.job_id.0.as_str()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! crate allows you to run Quil programs against real QPUs or a QVM
 //! using [`Executable`].
 
-pub use executable::{Error, Executable, Service};
+pub use executable::{Error, Executable, JobHandle, Service};
 pub use execution_data::ExecutionData;
 pub use register_data::RegisterData;
 


### PR DESCRIPTION
Resolves #126.

BREAKING CHANGE: added `#[must_use]` to `JobHandle::job_id` at clippy's
suggestion.