### PR TITLE
ci: use knope 0.6.1 in release dry run and secrets.PAT to auth with gh

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,20 +18,19 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     env:
-      REMOTE_REPO: https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git
-      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        token: ${{ secrets.PAT }}
     - name: Install Knope
       uses: knope-dev/action@v1
       with:
         version: 0.6.1 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config user.name "github-actions[bot]"
-        git remote set-url origin "${REMOTE_REPO}"
+        git config --global user.name "${{ github.triggering_actor }}"
+        git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"
     - name: Prepare Prerelease
       run: knope prerelease
       if: github.event_name == 'push'

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -14,13 +14,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
       - name: Install Knope
-        run: |
-          wget https://github.com/knope-dev/knope/releases/download/$KNOPE_VERSION/knope-x86_64-unknown-linux-musl-$KNOPE_VERSION.tgz
-          tar -xvf knope-x86_64-unknown-linux-musl-$KNOPE_VERSION.tgz
-          cp knope-x86_64-unknown-linux-musl-$KNOPE_VERSION/knope $HOME/.cargo/bin
-          rm -rf knope-x86_64-unknown-linux-musl-${KNOPE_VERSION}*
-        env:
-          KNOPE_VERSION: v0.4.1
+        uses: knope-dev/action@v1
+        with:
+          version: 0.6.1 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
       - name: Display Pending Release
         run: knope release --dry-run
         env:

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -20,3 +20,4 @@ jobs:
       - uses: katyo/publish-crates@v1
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
+          path: './crates/lib'

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -3,7 +3,7 @@ name: Release Python
 on:
   push:
     tags:
-      - python/v*
+      - 'python/v**'
 
 jobs:
   macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
-name: Release
+name: Release Rust
 
 on:
-  workflow_dispatch
+  push:
+    tags:
+      - 'lib/v**'
 
 jobs:
   release:
@@ -11,18 +13,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
-      - name: Install Knope
-        uses: knope-dev/action@v1
-        with:
-          version: 0.6.1 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
-      - name: Configure Git
-        run: |
-          git config --global user.name "${{ github.triggering_actor }}"
-          git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"
-      - name: Create Release
-        run: knope release
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To build the docs.rs-style docs, run `makers docs`. You can also do `makers serv
 
 To release the library crate or the bindings to Python, manually run the `release` or `release python` workflow in GitHub Actions, respectively.
 
-Pre-releases of the Python package happen automatically on merge to main.
+Pre-releases for both the library crate and Python package happen automatically on merge to main.
 
 [cargo-make]: https://sagiegurari.github.io/cargo-make/
 [Quantum Cloud Services]: https://docs.rigetti.com/qcs/


### PR DESCRIPTION
Fixes for the two workflows that failed after merging #145

[Release Dry Run](https://github.com/rigetti/qcs-sdk-rust/actions/runs/3055481949/jobs/4928586660) failed because it was still pointing to an old version of knope (was 0.4.1, now 0.6.1)

[Prepare Release](https://github.com/rigetti/qcs-sdk-rust/actions/runs/3055481949/jobs/4928586660) failed because `GITHUB_TOKEN` can't be used to push to a protected branch (and can't be configured to do so safely). I took inspiration from the release workflow and use the already configured `secrets.PAT` instead.

While looking at the `Release` workflow, I realized it should probably be following the same pattern for releases as the Python package, so I updated it. 