### PR TITLE
ci: trigger releases on release events instead of tags being pushed

### DIFF
--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -1,12 +1,14 @@
 name: Release Rust
 
 on:
-  push:
-    tags:
-      - 'lib/v**'
+  release:
+    types: [published]
+  workflow_dispatch:
+    description: "Manually publish release"
 
 jobs:
   release:
+    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "lib/v") }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -7,9 +7,15 @@ on:
     description: "Manually publish release"
 
 jobs:
-  release:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'lib/v') }}
+  is-lib-release:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'lib/v') }}
+    steps:
+      - run: echo "Release tag starts with lib/v, proceeding with release"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: is-lib-release
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "lib/v") }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'lib/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   macos:
-    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
     runs-on: macos-11
     strategy:
       matrix:
@@ -49,7 +49,7 @@ jobs:
           name: wheels
           path: dist
   linux:
-    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,7 +79,7 @@ jobs:
         path: dist
 
   release:
-    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
     name: Release
     runs-on: ubuntu-latest
     needs: [ macos, linux ]

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,12 +1,15 @@
 name: Release Python
 
 on:
-  push:
-    tags:
-      - 'python/v**'
+  release:
+    types: [published]
+  workflow_dispatch:
+    description: "Manually publish release"
+
 
 jobs:
   macos:
+    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
     runs-on: macos-11
     strategy:
       matrix:
@@ -46,6 +49,7 @@ jobs:
           name: wheels
           path: dist
   linux:
+    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -75,6 +79,7 @@ jobs:
         path: dist
 
   release:
+    if: ${{ github.event_name == "workflow_dispatch" || startsWith(github.event.release.tag_name, "python/v") }}
     name: Release
     runs-on: ubuntu-latest
     needs: [ macos, linux ]

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -8,9 +8,15 @@ on:
 
 
 jobs:
-  macos:
+  is-python-release:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Release tag starts with python/v, proceeding with release"
+
+  macos:
     runs-on: macos-11
+    needs: is-python-release
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
@@ -48,9 +54,10 @@ jobs:
         with:
           name: wheels
           path: dist
+
   linux:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
     runs-on: ubuntu-latest
+    needs: is-python-release
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
@@ -79,7 +86,6 @@ jobs:
         path: dist
 
   release:
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'python/v') }}
     name: Release
     runs-on: ubuntu-latest
     needs: [ macos, linux ]


### PR DESCRIPTION
`[skip ci]` applies to _all_ push events, including tag creation. This means that the tags `knope` creates don't trigger the workflows, since it pushes a `[skip ci]` commit right before.  

Setting these workflows up to run on `release` events instead. The `published` event triggers on pre-release and release creation, as well as when pre-releases are promoted to full releases. I also added `workflow_dispatch` as an option just so we have the flexibility of kicking these off on our own terms.

I've manually verified these with [act](https://github.com/nektos/act). 

```sh
act release --dryrun -e payload.json
```

Where `payload.json` is mocking the [release webhook payload](https://docs.github.com/en/rest/releases/releases#get-a-release) with `tag_name`
```json
{
	"release": {
		"tag_name": "lib/v1.0.0"
	}
}
```
