### PR TITLE
fix: make grpc_api_url optional in settings.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef0fc0cc285ced05d1f67d4751285a5e5c5a85390b0b53fcd3ab8218bacb597"
+checksum = "84ce4e2d8e5fde2614fe00fc294282dd5eb0b3c6c6f0a23c9c1a66505e63e44e"
 dependencies = [
  "dirs",
  "futures",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-grpc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c466015e50e233b2a1c5c718261725f6e0cf67f4d86c3a367c7b512090bfc802"
+checksum = "3cd8bdf316811d1a5fc23165654da6ad0676091a92b09e80a53bb666897cd91f"
 dependencies = [
  "http-body",
  "pbjson",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-openapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee37999a0faa451a7aab9cd1f4c059737ae6c3585dc9f549ebf4089badded985"
+checksum = "c8a1f244ce60c40feff71fc21b919f964f5baa2e1012de755c98b39cc065d160"
 dependencies = [
  "qcs-api-client-common",
  "reqwest",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -21,9 +21,9 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 num = "0.4.0"
 qcs-api = "0.2.1"
-qcs-api-client-common = "0.2.5"
-qcs-api-client-openapi = "0.3.5"
-qcs-api-client-grpc = "0.2.5"
+qcs-api-client-common = "0.2.6"
+qcs-api-client-openapi = "0.3.6"
+qcs-api-client-grpc = "0.2.6"
 quil-rs = "0.14"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
 rmp-serde = "1.1.1"
@@ -42,7 +42,7 @@ erased-serde = "0.3.23"
 float-cmp = "0.9.0"
 hex = "0.4.3"
 maplit = "1.0.2"
-qcs-api-client-grpc = { version = "0.2.4", features = ["server"] }
+qcs-api-client-grpc = { version = "0.2.6", features = ["server"] }
 simple_logger = { version = "2.3.0", default-features = false }
 tempfile = "3.3.0"
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 qcs = { path = "../lib" }
-qcs-api-client-common = "0.2.5"
+qcs-api-client-common = "0.2.6"
 pyo3 = { version = "0.17", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.17", features = ["tokio-runtime"] }
 pythonize = "0.17"


### PR DESCRIPTION
`qcs-api-client` was requiring `grpc_api_url` to exist in `settings.toml`. `0.2.6` makes the value optional and prevents errors from occurring when it's not defined in operations that don't need it.