### PR TITLE
feat!: make compiler timeout configurable

### DIFF
--- a/crates/lib/src/api.rs
+++ b/crates/lib/src/api.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use crate::qpu::{
     self,
     client::{GrpcClientError, Qcs},
-    quilc::{self, TargetDevice},
+    quilc::{self, CompilerOpts, TargetDevice},
     rewrite_arithmetic::{self, Substitutions},
     runner,
     translation::{self, EncryptedTranslationResult},
@@ -31,9 +31,9 @@ pub fn compile(
     quil: &str,
     target: TargetDevice,
     client: &Qcs,
-    timeout: Option<u8>,
+    options: &CompilerOpts,
 ) -> Result<String, Box<dyn std::error::Error + 'static>> {
-    quilc::compile_program(quil, target, client, timeout)
+    quilc::compile_program(quil, target, client, options)
         .map_err(Into::into)
         .map(|p| p.to_string(true))
 }

--- a/crates/lib/src/api.rs
+++ b/crates/lib/src/api.rs
@@ -31,7 +31,7 @@ pub fn compile(
     quil: &str,
     target: TargetDevice,
     client: &Qcs,
-    options: &CompilerOpts,
+    options: CompilerOpts,
 ) -> Result<String, Box<dyn std::error::Error + 'static>> {
     quilc::compile_program(quil, target, client, options)
         .map_err(Into::into)

--- a/crates/lib/src/api.rs
+++ b/crates/lib/src/api.rs
@@ -31,8 +31,9 @@ pub fn compile(
     quil: &str,
     target: TargetDevice,
     client: &Qcs,
+    timeout: Option<u8>,
 ) -> Result<String, Box<dyn std::error::Error + 'static>> {
-    quilc::compile_program(quil, target, client)
+    quilc::compile_program(quil, target, client, timeout)
         .map_err(Into::into)
         .map(|p| p.to_string(true))
 }

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -68,6 +68,7 @@ pub struct Executable<'executable, 'execution> {
     readout_memory_region_names: Option<Vec<&'executable str>>,
     params: Parameters,
     compile_with_quilc: bool,
+    compiler_timeout: Option<u8>,
     config: Option<ClientConfiguration>,
     client: Option<Arc<Qcs>>,
     qpu: Option<qpu::Execution<'execution>>,
@@ -99,6 +100,7 @@ impl<'executable> Executable<'executable, '_> {
             readout_memory_region_names: None,
             params: Parameters::new(),
             compile_with_quilc: true,
+            compiler_timeout: None,
             config: None,
             client: None,
             qpu: None,
@@ -252,6 +254,13 @@ impl Executable<'_, '_> {
         self
     }
 
+    /// If set, the value will override the default compiler timeout of 10s
+    #[must_use]
+    pub fn compiler_timeout(mut self, seconds: u8) -> Self {
+        self.compiler_timeout = Some(seconds);
+        self
+    }
+
     fn get_readouts(&self) -> &[&str] {
         return self
             .readout_memory_region_names
@@ -333,6 +342,7 @@ impl<'execution> Executable<'_, 'execution> {
             id,
             self.get_client().await?,
             self.compile_with_quilc,
+            None,
         )
         .await
         .map_err(Error::from)

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -342,7 +342,7 @@ impl<'execution> Executable<'_, 'execution> {
             id,
             self.get_client().await?,
             self.compile_with_quilc,
-            None,
+            self.compiler_timeout,
         )
         .await
         .map_err(Error::from)

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -10,6 +10,7 @@ use qcs_api_client_common::ClientConfiguration;
 
 use crate::execution_data;
 use crate::qpu::client::Qcs;
+use crate::qpu::quilc::CompilerOpts;
 use crate::qpu::rewrite_arithmetic;
 use crate::qpu::runner::JobId;
 use crate::qpu::ExecutionError;
@@ -68,7 +69,7 @@ pub struct Executable<'executable, 'execution> {
     readout_memory_region_names: Option<Vec<&'executable str>>,
     params: Parameters,
     compile_with_quilc: bool,
-    compiler_timeout: Option<u8>,
+    compiler_options: CompilerOpts,
     config: Option<ClientConfiguration>,
     client: Option<Arc<Qcs>>,
     qpu: Option<qpu::Execution<'execution>>,
@@ -100,7 +101,7 @@ impl<'executable> Executable<'executable, '_> {
             readout_memory_region_names: None,
             params: Parameters::new(),
             compile_with_quilc: true,
-            compiler_timeout: None,
+            compiler_options: CompilerOpts::default(),
             config: None,
             client: None,
             qpu: None,
@@ -254,10 +255,10 @@ impl Executable<'_, '_> {
         self
     }
 
-    /// If set, the value will override the default compiler timeout of 10s
+    /// If set, the value will override the default compiler options
     #[must_use]
-    pub fn compiler_timeout(mut self, seconds: u8) -> Self {
-        self.compiler_timeout = Some(seconds);
+    pub fn compiler_options(mut self, options: CompilerOpts) -> Self {
+        self.compiler_options = options;
         self
     }
 
@@ -342,7 +343,7 @@ impl<'execution> Executable<'_, 'execution> {
             id,
             self.get_client().await?,
             self.compile_with_quilc,
-            self.compiler_timeout,
+            self.compiler_options,
         )
         .await
         .map_err(Error::from)

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -92,8 +92,11 @@ impl<'a> Execution<'a> {
     /// * `quil`: The raw Quil program to eventually be run on a QPU.
     /// * `shots`: The number of times to run this program with each call to [`Execution::run`].
     /// * `quantum_processor_id`: The QPU this Quil will be run on and should be compiled for.
-    /// * `config`: A [`Configuration`] instance provided by the user which contains connection info
+    /// * `client`: A [`qcs::qpu::client`] instance provided by the user which contains connection info
     ///     for QCS and the `quilc` compiler.
+    /// * `compile_with_quilc`: A boolean that if set, will compile the given `quil` using `quilc`
+    /// * `compiler_timeout`: How many seconds to wait for compilation to finish. Has no effect if
+    ///     `compile_with_quilc` is false.
     ///
     /// returns: Result<Execution, Report>
     ///
@@ -113,6 +116,7 @@ impl<'a> Execution<'a> {
         quantum_processor_id: &'a str,
         client: Arc<Qcs>,
         compile_with_quilc: bool,
+        compiler_timeout: Option<u8>,
     ) -> Result<Execution<'a>, Error> {
         let isa = get_isa(quantum_processor_id, &client).await?;
         let target_device = TargetDevice::try_from(isa)?;
@@ -120,14 +124,16 @@ impl<'a> Execution<'a> {
         let program = if compile_with_quilc {
             trace!("Converting to Native Quil");
             let client = client.clone();
-            spawn_blocking(move || quilc::compile_program(&quil, target_device, &client))
-                .await
-                .map_err(|source| {
-                    Error::Unexpected(Unexpected::TaskError {
-                        task_name: "quilc",
-                        source,
-                    })
-                })??
+            spawn_blocking(move || {
+                quilc::compile_program(&quil, target_device, &client, compiler_timeout)
+            })
+            .await
+            .map_err(|source| {
+                Error::Unexpected(Unexpected::TaskError {
+                    task_name: "quilc",
+                    source,
+                })
+            })??
         } else {
             trace!("Skipping conversion to Native Quil");
             quil.parse().map_err(Error::Quil)?

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -125,7 +125,7 @@ impl<'a> Execution<'a> {
             trace!("Converting to Native Quil");
             let client = client.clone();
             spawn_blocking(move || {
-                quilc::compile_program(&quil, target_device, &client, &compiler_options)
+                quilc::compile_program(&quil, target_device, &client, compiler_options)
             })
             .await
             .map_err(|source| {

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -92,7 +92,7 @@ impl<'a> Execution<'a> {
     /// * `quil`: The raw Quil program to eventually be run on a QPU.
     /// * `shots`: The number of times to run this program with each call to [`Execution::run`].
     /// * `quantum_processor_id`: The QPU this Quil will be run on and should be compiled for.
-    /// * `client`: A [`qcs::qpu::client`] instance provided by the user which contains connection info
+    /// * `client`: A [`qcs::qpu::client::Qcs`] instance provided by the user which contains connection info
     ///     for QCS and the `quilc` compiler.
     /// * `compile_with_quilc`: A boolean that if set, will compile the given `quil` using `quilc`
     /// * `compiler_timeout`: How many seconds to wait for compilation to finish. Has no effect if

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -21,6 +21,7 @@ mod isa;
 /// * `program`: The Quil program to compile.
 /// * `isa`: The [`InstructionSetArchitecture`] of the targeted platform. Get this using
 ///     [`super::get_isa`].
+/// * `timeout`: The number of seconds to wait before timing out. If not set, defaults to 10.
 ///
 /// returns: `eyre::Result<quil_rs::Program>`
 ///

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -14,6 +14,9 @@ use super::{rpcq, Qcs};
 
 mod isa;
 
+/// Number of seconds to wait before timing out.
+pub const DEFAULT_COMPILER_TIMEOUT: u8 = 30;
+
 /// Take in a Quil program and produce a "native quil" output from quilc
 ///
 /// # Arguments
@@ -21,7 +24,7 @@ mod isa;
 /// * `program`: The Quil program to compile.
 /// * `isa`: The [`InstructionSetArchitecture`] of the targeted platform. Get this using
 ///     [`super::get_isa`].
-/// * `timeout`: The number of seconds to wait before timing out. If not set, defaults to 10.
+/// * `timeout`: The number of seconds to wait before timing out. If not set, defaults to 30.
 ///
 /// returns: `eyre::Result<quil_rs::Program>`
 ///
@@ -81,7 +84,9 @@ impl Default for CompilerOpts {
     /// Default compiler options
     /// * `timeout`: 30 seconds
     fn default() -> Self {
-        Self { timeout: Some(30) }
+        Self {
+            timeout: Some(DEFAULT_COMPILER_TIMEOUT),
+        }
     }
 }
 

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -69,7 +69,7 @@ impl CompilerOpts {
         Self { timeout: None }
     }
 
-    /// Set the number of seconds to wait before timing out. If set to None, there is no timeout.
+    /// Set the number of seconds to wait before timing out. If set to None, the timeout is disabled.
     #[must_use]
     pub fn with_timeout(&mut self, seconds: Option<u8>) -> Self {
         self.timeout = seconds;

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -35,7 +35,7 @@ pub(crate) fn compile_program(
     quil: &str,
     isa: TargetDevice,
     client: &Qcs,
-    options: &CompilerOpts,
+    options: CompilerOpts,
 ) -> Result<quil_rs::Program, Error> {
     let config = client.get_config();
     let endpoint = config.quilc_url();
@@ -64,11 +64,13 @@ pub struct CompilerOpts {
 impl CompilerOpts {
     /// Creates a new instance of [`CompilerOpts`] with zero values for each option.
     /// Consider using [`CompilerOpts::default()`] to create an instance with recommended defaults.
+    #[must_use]
     pub fn new() -> Self {
         Self { timeout: None }
     }
 
     /// Set the number of seconds to wait before timing out. If set to None, there is no timeout.
+    #[must_use]
     pub fn with_timeout(&mut self, seconds: Option<u8>) -> Self {
         self.timeout = seconds;
         *self
@@ -208,7 +210,7 @@ mod tests {
             "MEASURE 0",
             TargetDevice::try_from(qvm_isa()).expect("Couldn't build target device from ISA"),
             &Qcs::load().await.unwrap_or_default(),
-            &CompilerOpts::default(),
+            CompilerOpts::default(),
         )
         .expect("Could not compile");
         assert_eq!(output.to_string(true), EXPECTED_H0_OUTPUT);
@@ -230,7 +232,7 @@ MEASURE 1 ro[1]
             BELL_STATE,
             TargetDevice::try_from(aspen_9_isa()).expect("Couldn't build target device from ISA"),
             &client,
-            &CompilerOpts::default(),
+            CompilerOpts::default(),
         )
         .expect("Could not compile");
         let mut results = crate::qvm::Execution::new(&output.to_string(true))

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn compile_program(
 /// A set of options that determine the behavior of compiling programs with quilc
 #[derive(Clone, Copy, Debug)]
 pub struct CompilerOpts {
-    /// The number of seconds to wait before timing out. If unset, there is no timeout
+    /// The number of seconds to wait before timing out. If `None`, there is no timeout.
     timeout: Option<u8>,
 }
 

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -24,7 +24,7 @@ pub const DEFAULT_COMPILER_TIMEOUT: u8 = 30;
 /// * `program`: The Quil program to compile.
 /// * `isa`: The [`InstructionSetArchitecture`] of the targeted platform. Get this using
 ///     [`super::get_isa`].
-/// * `timeout`: The number of seconds to wait before timing out. If not set, defaults to 30.
+/// * `timeout`: The number of seconds to wait before timing out. If not set, defaults to [`DEFAULT_COMPILER_TIMEOUT`].
 ///
 /// returns: `eyre::Result<quil_rs::Program>`
 ///

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -82,7 +82,7 @@ impl CompilerOpts {
 
 impl Default for CompilerOpts {
     /// Default compiler options
-    /// * `timeout`: 30 seconds
+    /// * `timeout`: See [`DEFAULT_COMPILER_TIMEOUT`]
     fn default() -> Self {
         Self {
             timeout: Some(DEFAULT_COMPILER_TIMEOUT),

--- a/crates/lib/src/qpu/quilc/mod.rs
+++ b/crates/lib/src/qpu/quilc/mod.rs
@@ -35,15 +35,13 @@ pub(crate) fn compile_program(
     quil: &str,
     isa: TargetDevice,
     client: &Qcs,
-    timeout: Option<u8>,
+    options: &CompilerOpts,
 ) -> Result<quil_rs::Program, Error> {
     let config = client.get_config();
     let endpoint = config.quilc_url();
     let params = QuilcParams::new(quil, isa);
-    let mut request = rpcq::RPCRequest::new("quil_to_native_quil", &params);
-    if let Some(seconds) = timeout {
-        request.with_timeout(seconds);
-    }
+    let request =
+        rpcq::RPCRequest::new("quil_to_native_quil", &params).with_timeout(options.timeout);
     let rpcq_client = rpcq::Client::new(endpoint)
         .map_err(|source| Error::from_quilc_error(endpoint.into(), source))?;
     match rpcq_client.run_request::<_, QuilcCompileProgramResponse>(&request) {
@@ -52,6 +50,36 @@ pub(crate) fn compile_program(
             .parse::<quil_rs::Program>()
             .map_err(Error::Parse),
         Err(source) => Err(Error::from_quilc_error(endpoint.into(), source)),
+    }
+}
+
+/// A set of options that determine the behavior of compiling programs with quilc
+#[derive(Clone, Copy, Debug)]
+pub struct CompilerOpts {
+    /// The number of seconds to wait before timing out. If unset, there is no timeout
+    timeout: Option<u8>,
+}
+
+/// Functions for building a [`CompilerOpts`] instance
+impl CompilerOpts {
+    /// Creates a new instance of [`CompilerOpts`] with zero values for each option.
+    /// Consider using [`CompilerOpts::default()`] to create an instance with recommended defaults.
+    pub fn new() -> Self {
+        Self { timeout: None }
+    }
+
+    /// Set the number of seconds to wait before timing out. If set to None, there is no timeout.
+    pub fn with_timeout(&mut self, seconds: Option<u8>) -> Self {
+        self.timeout = seconds;
+        *self
+    }
+}
+
+impl Default for CompilerOpts {
+    /// Default compiler options
+    /// * `timeout`: 30 seconds
+    fn default() -> Self {
+        Self { timeout: Some(30) }
     }
 }
 
@@ -180,7 +208,7 @@ mod tests {
             "MEASURE 0",
             TargetDevice::try_from(qvm_isa()).expect("Couldn't build target device from ISA"),
             &Qcs::load().await.unwrap_or_default(),
-            None,
+            &CompilerOpts::default(),
         )
         .expect("Could not compile");
         assert_eq!(output.to_string(true), EXPECTED_H0_OUTPUT);
@@ -202,7 +230,7 @@ MEASURE 1 ro[1]
             BELL_STATE,
             TargetDevice::try_from(aspen_9_isa()).expect("Couldn't build target device from ISA"),
             &client,
-            None,
+            &CompilerOpts::default(),
         )
         .expect("Could not compile");
         let mut results = crate::qvm::Execution::new(&output.to_string(true))

--- a/crates/lib/src/qpu/rpcq.rs
+++ b/crates/lib/src/qpu/rpcq.rs
@@ -11,6 +11,8 @@ use zmq::{Context, Socket, SocketType};
 
 use crate::qpu::rpcq::Error::AuthSetup;
 
+pub(crate) const DEFAULT_CLIENT_TIMEOUT: u8 = 30;
+
 /// A minimal RPCQ client that does just enough to talk to `quilc` and QPU endpoints
 pub(crate) struct Client {
     socket: Socket,
@@ -176,7 +178,7 @@ impl<'params, T: Serialize> RPCRequest<'params, T> {
             params,
             id: Uuid::new_v4().to_string(),
             jsonrpc: "2.0",
-            client_timeout: Some(30),
+            client_timeout: Some(DEFAULT_CLIENT_TIMEOUT),
             client_key: None,
         }
     }

--- a/crates/lib/src/qpu/rpcq.rs
+++ b/crates/lib/src/qpu/rpcq.rs
@@ -157,7 +157,7 @@ where
     params: &'params T,
     id: String,
     jsonrpc: &'static str,
-    client_timeout: u8,
+    client_timeout: Option<u8>,
     client_key: Option<String>,
 }
 
@@ -176,7 +176,7 @@ impl<'params, T: Serialize> RPCRequest<'params, T> {
             params,
             id: Uuid::new_v4().to_string(),
             jsonrpc: "2.0",
-            client_timeout: 10,
+            client_timeout: Some(30),
             client_key: None,
         }
     }
@@ -185,10 +185,10 @@ impl<'params, T: Serialize> RPCRequest<'params, T> {
     ///
     /// # Arguments
     ///
-    /// * `seconds`: The number of seconds before timing out the request
+    /// * `seconds`: The number of seconds to wait before timing out, or None for no timeout
     ///
     /// returns: `RPCRequest<T>` with the updated timeout.
-    pub fn with_timeout(&mut self, seconds: u8) -> &mut Self {
+    pub fn with_timeout(mut self, seconds: Option<u8>) -> Self {
         self.client_timeout = seconds;
         self
     }

--- a/crates/lib/src/qpu/rpcq.rs
+++ b/crates/lib/src/qpu/rpcq.rs
@@ -188,7 +188,7 @@ impl<'params, T: Serialize> RPCRequest<'params, T> {
     /// * `seconds`: The number of seconds before timing out the request
     ///
     /// returns: `RPCRequest<T>` with the updated timeout.
-    pub fn with_timeout(mut self, seconds: u8) -> Self {
+    pub fn with_timeout(&mut self, seconds: u8) -> &mut Self {
         self.client_timeout = seconds;
         self
     }

--- a/crates/lib/src/qpu/rpcq.rs
+++ b/crates/lib/src/qpu/rpcq.rs
@@ -180,6 +180,18 @@ impl<'params, T: Serialize> RPCRequest<'params, T> {
             client_key: None,
         }
     }
+
+    /// Sets the client timeout for the [`RPCRequest`].
+    ///
+    /// # Arguments
+    ///
+    /// * `seconds`: The number of seconds before timing out the request
+    ///
+    /// returns: `RPCRequest<T>` with the updated timeout.
+    pub fn with_timeout(mut self, seconds: u8) -> Self {
+        self.client_timeout = seconds;
+        self
+    }
 }
 
 /// Credentials for connecting to RPCQ Server

--- a/crates/python/qcs_sdk.pyi
+++ b/crates/python/qcs_sdk.pyi
@@ -69,13 +69,14 @@ class ExecutionResults(TypedDict):
     The time spent executing the program.
     """
 
-async def compile(quil: str, target_device: str) -> str:
+async def compile(quil: str, target_device: str, timeout: int=10) -> str:
     """
     Uses quilc to convert a quil program to native Quil.
 
     Args:
         quil: A Quil program.
         target_device: A JSON encoded description of the Quantum Abstract Machine Architecture.
+        timeout: The number of seconds to wait before timing out (default: 10).
 
     Returns:
         An Awaitable that resolves to the native Quil program.

--- a/crates/python/qcs_sdk.pyi
+++ b/crates/python/qcs_sdk.pyi
@@ -69,14 +69,16 @@ class ExecutionResults(TypedDict):
     The time spent executing the program.
     """
 
-async def compile(quil: str, target_device: str, timeout: int=10) -> str:
+async def compile(quil: str, target_device: str, *, timeout: int = 30) -> str:
     """
     Uses quilc to convert a quil program to native Quil.
 
     Args:
         quil: A Quil program.
         target_device: A JSON encoded description of the Quantum Abstract Machine Architecture.
-        timeout: The number of seconds to wait before timing out (default: 10).
+
+    Keyword Args:
+        timeout: The number of seconds to wait before timing out. If set to None, there is no timeout (default: 30).
 
     Returns:
         An Awaitable that resolves to the native Quil program.
@@ -144,9 +146,7 @@ async def submit(
     """
     ...
 
-async def retrieve_results(
-    job_id: str, quantum_processor_id: str
-) -> ExecutionResults:
+async def retrieve_results(job_id: str, quantum_processor_id: str) -> ExecutionResults:
     """
     Fetches results for the corresponding job ID.
 

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -43,7 +43,7 @@ fn compile<'a>(
             .await
             .map_err(|e| InvalidConfigError::new_err(e.to_string()))?;
         let options = CompilerOpts::default().with_timeout(compiler_timeout);
-        let result = api::compile(&quil, target_device, &client, &options)
+        let result = api::compile(&quil, target_device, &client, options)
             .map_err(|e| CompilationError::new_err(e.to_string()))?;
         Ok(Python::with_gil(|_py| result))
     })

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -18,14 +18,19 @@ create_exception!(qcs, RewriteArithmeticError, PyRuntimeError);
 create_exception!(qcs, DeviceIsaError, PyValueError);
 
 #[pyfunction]
-fn compile(py: Python<'_>, quil: String, target_device: String) -> PyResult<&PyAny> {
+fn compile(
+    py: Python<'_>,
+    quil: String,
+    target_device: String,
+    compiler_timeout: Option<u8>,
+) -> PyResult<&PyAny> {
     let target_device: TargetDevice =
         serde_json::from_str(&target_device).map_err(|e| DeviceIsaError::new_err(e.to_string()))?;
     pyo3_asyncio::tokio::future_into_py(py, async move {
         let client = Qcs::load()
             .await
             .map_err(|e| InvalidConfigError::new_err(e.to_string()))?;
-        let result = api::compile(&quil, target_device, &client)
+        let result = api::compile(&quil, target_device, &client, compiler_timeout)
             .map_err(|e| CompilationError::new_err(e.to_string()))?;
         Ok(Python::with_gil(|_py| result))
     })

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -1,7 +1,7 @@
 use pythonize::pythonize;
 use qcs::api;
 use qcs::qpu::client::Qcs;
-use qcs::qpu::quilc::{CompilerOpts, TargetDevice};
+use qcs::qpu::quilc::{CompilerOpts, TargetDevice, DEFAULT_COMPILER_TIMEOUT};
 use std::collections::HashMap;
 
 use pyo3::{
@@ -28,7 +28,7 @@ fn compile<'a>(
     let target_device: TargetDevice =
         serde_json::from_str(&target_device).map_err(|e| DeviceIsaError::new_err(e.to_string()))?;
 
-    let mut compiler_timeout = Some(30);
+    let mut compiler_timeout = Some(DEFAULT_COMPILER_TIMEOUT);
     if let Some(kwargs) = kwds {
         if let Some(timeout_arg) = kwargs.get_item("timeout") {
             let timeout: Result<Option<u8>, _> = timeout_arg.extract();

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -22,7 +22,7 @@ fn compile(
     py: Python<'_>,
     quil: String,
     target_device: String,
-    compiler_timeout: Option<u8>,
+    timeout: Option<u8>,
 ) -> PyResult<&PyAny> {
     let target_device: TargetDevice =
         serde_json::from_str(&target_device).map_err(|e| DeviceIsaError::new_err(e.to_string()))?;
@@ -30,7 +30,7 @@ fn compile(
         let client = Qcs::load()
             .await
             .map_err(|e| InvalidConfigError::new_err(e.to_string()))?;
-        let result = api::compile(&quil, target_device, &client, compiler_timeout)
+        let result = api::compile(&quil, target_device, &client, timeout)
             .map_err(|e| CompilationError::new_err(e.to_string()))?;
         Ok(Python::with_gil(|_py| result))
     })


### PR DESCRIPTION
Closes #209 

* `quilc::compile_program` now takes a `timeout: Option<u8>` parameter for overriding the default timeout.
* `Execution::new` now takes a `compiler_timeout: Option<u8>` parameter, since it calls out to `compile_program`.

