### PR TITLE
fix: Fetch Gateway address with pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-openapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28810a4421531e887f846e071bb78ea8c5b57c13894c0a40c4919f5f530f908"
+checksum = "de8ce34a5f6d100626d19f28219a2c791f11d7809a36521979c3817dfaac8f3a"
 dependencies = [
  "qcs-api-client-common",
  "reqwest",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.17"
 num = "0.4.0"
 qcs-api = "0.2.1"
 qcs-api-client-common = "0.2.7"
-qcs-api-client-openapi = "0.3.7"
+qcs-api-client-openapi = "0.3.8"
 qcs-api-client-grpc = "0.2.7"
 quil-rs = "0.14"
 reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -136,6 +136,7 @@ impl Qcs {
             .await?;
             gateways.extend(accessors.accessors.into_iter().filter(|acc| {
                 acc.live
+                    // `as_deref` needed to work around the `Option<Box<_>>` type.
                     && acc.access_type.as_deref() == Some(&QuantumProcessorAccessorType::GatewayV1)
             }));
             next_page_token = accessors.next_page_token.clone();
@@ -144,7 +145,9 @@ impl Qcs {
             }
         }
         gateways.sort_by_key(|acc| acc.rank);
-        let target = gateways.first().ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
+        let target = gateways
+            .first()
+            .ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
         parse_uri(&target.url).map_err(GrpcEndpointError::BadUri)
     }
 }

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -144,7 +144,7 @@ impl Qcs {
             }
         }
         gateways.sort_by_key(|acc| acc.rank);
-        let target = gateways.first().ok_or(GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
+        let target = gateways.first().ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
         parse_uri(&target.url).map_err(GrpcEndpointError::BadUri)
     }
 }

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 qcs = { path = "../lib" }
-qcs-api-client-common = "0.2.6"
+qcs-api-client-common = "0.2.7"
 pyo3 = { version = "0.17", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.17", features = ["tokio-runtime"] }
 pythonize = "0.17"


### PR DESCRIPTION
Remove `GATEWAY_ADDR` environment variable and fully paginate accessor results to find the highest priority Gateway.