### PR TITLE
fix: add missing types and fix others needed from pyquil

### DIFF
--- a/crates/python/qcs_sdk/compiler/quilc.pyi
+++ b/crates/python/qcs_sdk/compiler/quilc.pyi
@@ -53,6 +53,19 @@ class TargetDevice:
         """
         ...
 
+    @staticmethod
+    def from_json(
+        value: str,
+    ) -> "TargetDevice":
+        """
+        Create a ``TargetDevice`` based on its JSON representation.
+
+        :param value: The JSON representation of a ``TargetDevice`` that describes the target device.
+
+        :raises ValueError: If the JSON is malformed.
+        """
+        ...
+
 
 def compile_program(
     quil: str,

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -55,8 +55,8 @@ class ExecutionResult:
         ...
 
     @property
-    def data(self) -> List[Register]:
-        """The result data. Complex numbers are represented as [real, imaginary]."""
+    def data(self) -> Register:
+        """The result data for all shots by the particular memory location."""
         ...
 
     @property

--- a/crates/python/src/compiler/quilc.rs
+++ b/crates/python/src/compiler/quilc.rs
@@ -1,3 +1,4 @@
+use pyo3::exceptions::PyValueError;
 use pyo3::{exceptions::PyRuntimeError, pyfunction, pymethods, PyResult};
 use qcs::compiler::quilc::{CompilerOpts, TargetDevice, DEFAULT_COMPILER_TIMEOUT};
 use qcs_api_client_openapi::models::InstructionSetArchitecture;
@@ -63,6 +64,15 @@ impl PyTargetDevice {
             .try_into()
             .map_err(RustQuilcError::from)
             .map_err(RustQuilcError::to_py_err)?;
+
+        Ok(Self(target))
+    }
+
+    #[staticmethod]
+    pub fn from_json(value: String) -> PyResult<Self> {
+        let target: TargetDevice = serde_json::from_str(&value)
+            .map_err(|err| err.to_string())
+            .map_err(PyValueError::new_err)?;
 
         Ok(Self(target))
     }


### PR DESCRIPTION
Should have been included in #255

- PyQuil defines it's own `TargetDevice` that has the same JSON representation of the `qcs_sdk` one, used for quilc compilation.
- `ExecutionResults` data is a register, lot a list of registers.