### PR TITLE
fix!: remove python 3.7 support

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -19,7 +19,7 @@ jobs:
     needs: is-python-release
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -27,7 +27,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Rust
         uses: actions-rs/toolchain@v1
-        if: matrix.python-version != '3.7'
         with:
           toolchain: stable
           target: aarch64-apple-darwin
@@ -38,16 +37,8 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: '3.20.1'
-      - name: Build wheels - x86_64
-        # Python 3.7 does not support aarch64 so we only build it for x86_64
-        if: matrix.python-version == '3.7'
-        uses: messense/maturin-action@v1
-        with:
-          target: x86_64
-          args: -i python --release --manifest-path crates/python/Cargo.toml --out dist --sdist
       - name: Build wheels - universal2
-        # universal2 supports both x86_64 and aarch64 so every Python > 3.7 only needs this wheel
-        if: matrix.python-version != '3.7'
+        # universal2 supports both x86_64 and aarch64
         uses: messense/maturin-action@v1
         with:
           args: -i python --release --universal2 --manifest-path crates/python/Cargo.toml --out dist
@@ -65,7 +56,7 @@ jobs:
     needs: is-python-release
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         target: [x86_64, aarch64]
     steps:
     - uses: actions/checkout@v2

--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -14,9 +14,10 @@ authors = [
 classifiers = [
 	"Development Status :: 3 - Alpha",
 	"License :: OSI Approved :: Apache Software License",
-	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
+	"Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
 	"Operating System :: OS Independent",
 ]
 
@@ -51,7 +52,7 @@ black = "^22.8.0"
 
 [tool.black]
 line-length = 120
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 [build-system]


### PR DESCRIPTION
From https://github.com/rigetti/qcs-sdk-rust/issues/258

Seems the issue may be specifically the 3.7 build path.
Since `pyproject` specifies that the required python version be `^3.8`, seems 3.7 support could be removed anyway.