### PR TITLE
feat: support endpoint_id job target

### DIFF
--- a/crates/lib/examples/delayed_job_retrieval.rs
+++ b/crates/lib/examples/delayed_job_retrieval.rs
@@ -8,17 +8,18 @@ RX(pi) 0
 MEASURE 0 ro[0]
 "#;
 
+const QUANTUM_PROCESSOR_ID: &str = "Aspen-M-3";
+
 #[tokio::main]
 async fn main() {
     let mut exe = Executable::from_quil(PROGRAM);
-    let quantum_processor_id = "Aspen-M-3";
     let job_handle = exe
-        .submit_to_qpu(quantum_processor_id)
+        .submit_to_qpu(QUANTUM_PROCESSOR_ID)
         .await
         .expect("Program should be successfully submitted for execution");
     // Do some other stuff
     let _data = exe
-        .retrieve_results(quantum_processor_id, &job_handle)
+        .retrieve_results(job_handle)
         .await
         .expect("Results should be successfully retrieved");
 }

--- a/crates/lib/examples/delayed_job_retrieval.rs
+++ b/crates/lib/examples/delayed_job_retrieval.rs
@@ -11,13 +11,14 @@ MEASURE 0 ro[0]
 #[tokio::main]
 async fn main() {
     let mut exe = Executable::from_quil(PROGRAM);
+    let quantum_processor_id = "Aspen-M-3";
     let job_handle = exe
-        .submit_to_qpu("Aspen-M-3")
+        .submit_to_qpu(quantum_processor_id)
         .await
         .expect("Program should be successfully submitted for execution");
     // Do some other stuff
     let _data = exe
-        .retrieve_results(job_handle)
+        .retrieve_results(quantum_processor_id, &job_handle)
         .await
         .expect("Results should be successfully retrieved");
 }

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -687,7 +687,7 @@ impl<'a> JobHandle<'a> {
         self.job_id.clone()
     }
 
-    /// The string representation of the QCS Job ID. Useful for debugging.
+    /// The execution target of the QCS Job, either the quantum processor or an expicit endpoint.
     #[must_use]
     pub fn job_target(&self) -> JobTarget {
         self.endpoint_id.as_ref().map_or_else(

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -676,7 +676,7 @@ impl<'a> JobHandle<'a> {
         Self {
             job_id,
             quantum_processor_id: quantum_processor_id.into(),
-            endpoint_id: endpoint_id.map(|v| v.into()),
+            endpoint_id: endpoint_id.map(Into::into),
             readout_map,
         }
     }

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -36,6 +36,34 @@ pub(crate) fn params_into_job_execution_configuration(
     JobExecutionConfiguration { memory_values }
 }
 
+/// A QCS Job execution target, either a Quantum Processor ID or a specific endpoint.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum JobTarget {
+    /// Execute against a QPU's default endpoint.
+    QuantumProcessorId(String),
+
+    /// Execute against a specific endpoint by ID.
+    EndpointId(String),
+}
+
+impl From<&JobTarget> for execute_controller_job_request::Target {
+    fn from(value: &JobTarget) -> Self {
+        match value {
+            JobTarget::EndpointId(v) => Self::EndpointId(v.into()),
+            JobTarget::QuantumProcessorId(v) => Self::QuantumProcessorId(v.into()),
+        }
+    }
+}
+
+impl From<&JobTarget> for get_controller_job_results_request::Target {
+    fn from(value: &JobTarget) -> Self {
+        match value {
+            JobTarget::EndpointId(v) => Self::EndpointId(v.into()),
+            JobTarget::QuantumProcessorId(v) => Self::QuantumProcessorId(v.into()),
+        }
+    }
+}
+
 /// The QCS Job ID. Useful for debugging or retrieving results later.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct JobId(pub(crate) String);
@@ -54,7 +82,7 @@ impl ToString for JobId {
 
 /// Execute compiled program on a QPU.
 pub async fn submit(
-    quantum_processor_id: &str,
+    job_target: &JobTarget,
     program: EncryptedControllerJob,
     patch_values: &Parameters,
     client: &Qcs,
@@ -62,15 +90,22 @@ pub async fn submit(
     let request = ExecuteControllerJobRequest {
         execution_configurations: vec![params_into_job_execution_configuration(patch_values)],
         job: Some(execute_controller_job_request::Job::Encrypted(program)),
-        target: Some(execute_controller_job_request::Target::QuantumProcessorId(
-            quantum_processor_id.into(),
-        )),
+        target: Some(job_target.into()),
     };
 
+    let mut controller_client = match job_target {
+        JobTarget::EndpointId(endpoint_id) => {
+            client
+                .get_controller_client_with_endpoint_id(endpoint_id)
+                .await
+        }
+        JobTarget::QuantumProcessorId(quantum_processor_id) => {
+            client.get_controller_client(quantum_processor_id).await
+        }
+    }?;
+
     // we expect exactly one job ID since we only submit one execution configuration
-    let job_execution_id = client
-        .get_controller_client(quantum_processor_id)
-        .await?
+    let job_execution_id = controller_client
         .execute_controller_job(request)
         .await?
         .into_inner()
@@ -85,21 +120,26 @@ pub async fn submit(
 /// Fetch results from QPU job execution.
 pub async fn retrieve_results(
     job_id: JobId,
-    quantum_processor_id: &str,
+    job_target: &JobTarget,
     client: &Qcs,
 ) -> Result<ControllerJobExecutionResult, GrpcClientError> {
     let request = GetControllerJobResultsRequest {
         job_execution_id: Some(job_id.0),
-        target: Some(
-            get_controller_job_results_request::Target::QuantumProcessorId(
-                quantum_processor_id.into(),
-            ),
-        ),
+        target: Some(job_target.into()),
     };
 
-    client
-        .get_controller_client(quantum_processor_id)
-        .await?
+    let mut controller_client = match job_target {
+        JobTarget::EndpointId(endpoint_id) => {
+            client
+                .get_controller_client_with_endpoint_id(endpoint_id)
+                .await
+        }
+        JobTarget::QuantumProcessorId(quantum_processor_id) => {
+            client.get_controller_client(quantum_processor_id).await
+        }
+    }?;
+
+    controller_client
         .get_controller_job_results(request)
         .await?
         .into_inner()

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -136,7 +136,7 @@ impl Qcs {
             .await
     }
 
-    /// Get address for direction connection to Controller, when explicitly targeting a endpoint by ID.
+    /// Get address for direct connection to Controller, explicitly targeting an endpoint by ID.
     async fn get_controller_endpoint_by_id(
         &self,
         endpoint_id: &str,
@@ -217,11 +217,11 @@ pub enum GrpcEndpointError {
 
     /// Error due to missing gRPC endpoint for quantum processor
     #[error("Missing gRPC endpoint for quantum processor: {0}")]
-    NoQpuEndpoint(String),
+    QpuEndpointNotFound(String),
 
     /// Error due to missing gRPC endpoint for endpoint ID
     #[error("Missing gRPC endpoint for endpoint ID: {0}")]
-    NoEndpoint(String),
+    EndpointNotFound(String),
 }
 
 /// Errors that may occur while trying to use a `gRPC` client

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -145,7 +145,7 @@ impl Qcs {
         let grpc_address = endpoint.addresses.grpc;
 
         grpc_address
-            .ok_or_else(|| GrpcEndpointError::NoEndpoint(endpoint_id.into()))
+            .ok_or_else(|| GrpcEndpointError::EndpointNotFound(endpoint_id.into()))
             .map(|v| parse_uri(&v).map_err(GrpcEndpointError::BadUri))?
     }
 
@@ -159,7 +159,7 @@ impl Qcs {
         let addresses = default_endpoint.addresses.as_ref();
         let grpc_address = addresses.grpc.as_ref();
         grpc_address
-            .ok_or_else(|| GrpcEndpointError::NoQpuEndpoint(quantum_processor_id.into()))
+            .ok_or_else(|| GrpcEndpointError::QpuEndpointNotFound(quantum_processor_id.into()))
             .map(|v| parse_uri(v).map_err(GrpcEndpointError::BadUri))?
     }
 
@@ -189,9 +189,9 @@ impl Qcs {
             }
         }
         gateways.sort_by_key(|acc| acc.rank);
-        let target = gateways
-            .first()
-            .ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
+        let target = gateways.first().ok_or_else(|| {
+            GrpcEndpointError::QpuEndpointNotFound(quantum_processor_id.to_string())
+        })?;
         parse_uri(&target.url).map_err(GrpcEndpointError::BadUri)
     }
 }

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -149,18 +149,21 @@ impl<'a> Execution<'a> {
     }
 
     /// Run on a real QPU and wait for the results.
-    pub(crate) async fn submit(&mut self, params: &Parameters) -> Result<JobHandle, Error> {
+    pub(crate) async fn submit(&mut self, params: &Parameters) -> Result<JobHandle<'a>, Error> {
         let job_target = JobTarget::QuantumProcessorId(self.quantum_processor_id.to_string());
         self.submit_to_target(params, job_target).await
     }
 
     /// Run on specific QCS endpoint and wait for the results.
-    pub(crate) async fn submit_to_endpoint_id(
+    pub(crate) async fn submit_to_endpoint_id<S>(
         &mut self,
         params: &Parameters,
-        endpoint_id: Cow<'_, str>,
-    ) -> Result<JobHandle, Error> where {
-        let job_target = JobTarget::EndpointId(endpoint_id.to_string());
+        endpoint_id: S,
+    ) -> Result<JobHandle<'a>, Error>
+    where
+        S: Into<Cow<'a, str>>,
+    {
+        let job_target = JobTarget::EndpointId(endpoint_id.into().to_string());
         self.submit_to_target(params, job_target).await
     }
 
@@ -168,7 +171,7 @@ impl<'a> Execution<'a> {
         &mut self,
         params: &Parameters,
         job_target: JobTarget,
-    ) -> Result<JobHandle, Error> {
+    ) -> Result<JobHandle<'a>, Error> {
         let EncryptedTranslationResult { job, readout_map } = translate(
             self.quantum_processor_id.as_ref(),
             &self.program.to_string().0,
@@ -183,16 +186,26 @@ impl<'a> Execution<'a> {
 
         let job_id = submit(&job_target, job, &patch_values, self.client.as_ref()).await?;
 
-        Ok(JobHandle::new(job_id, job_target, readout_map))
+        let endpoint_id = match job_target {
+            JobTarget::EndpointId(endpoint_id) => Some(endpoint_id),
+            JobTarget::QuantumProcessorId(_) => None,
+        };
+
+        Ok(JobHandle::new(
+            job_id,
+            self.quantum_processor_id.to_string(),
+            endpoint_id,
+            readout_map,
+        ))
     }
 
     pub(crate) async fn retrieve_results(
         &self,
-        job_handle: &JobHandle,
+        job_handle: JobHandle<'a>,
     ) -> Result<ExecutionData, Error> {
         let response = retrieve_results(
             job_handle.job_id(),
-            job_handle.job_target(),
+            &job_handle.job_target(),
             self.client.as_ref(),
         )
         .await?;

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -1,7 +1,6 @@
 //! Contains QPU-specific executable stuff.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::Duration;
@@ -16,7 +15,7 @@ use crate::execution_data::{MemoryReferenceParseError, ResultData};
 use crate::qpu::{rewrite_arithmetic, translation::translate};
 use crate::{ExecutionData, JobHandle};
 
-use super::api::{retrieve_results, submit, JobId};
+use super::api::{retrieve_results, submit, JobTarget};
 use super::client::{GrpcClientError, Qcs};
 use super::rewrite_arithmetic::RewrittenProgram;
 use super::translation::EncryptedTranslationResult;
@@ -150,7 +149,26 @@ impl<'a> Execution<'a> {
     }
 
     /// Run on a real QPU and wait for the results.
-    pub(crate) async fn submit(&mut self, params: &Parameters) -> Result<JobHandle<'_>, Error> {
+    pub(crate) async fn submit(&mut self, params: &Parameters) -> Result<JobHandle, Error> {
+        let job_target = JobTarget::QuantumProcessorId(self.quantum_processor_id.to_string());
+        self.submit_to_target(params, job_target).await
+    }
+
+    /// Run on specific QCS endpoint and wait for the results.
+    pub(crate) async fn submit_to_endpoint_id(
+        &mut self,
+        params: &Parameters,
+        endpoint_id: Cow<'_, str>,
+    ) -> Result<JobHandle, Error> where {
+        let job_target = JobTarget::EndpointId(endpoint_id.to_string());
+        self.submit_to_target(params, job_target).await
+    }
+
+    async fn submit_to_target(
+        &mut self,
+        params: &Parameters,
+        job_target: JobTarget,
+    ) -> Result<JobHandle, Error> {
         let EncryptedTranslationResult { job, readout_map } = translate(
             self.quantum_processor_id.as_ref(),
             &self.program.to_string().0,
@@ -163,36 +181,25 @@ impl<'a> Execution<'a> {
             .get_substitutions(params)
             .map_err(Error::Substitution)?;
 
-        let job_id = submit(
-            self.quantum_processor_id.as_ref(),
-            job,
-            &patch_values,
-            self.client.as_ref(),
-        )
-        .await?;
+        let job_id = submit(&job_target, job, &patch_values, self.client.as_ref()).await?;
 
-        Ok(JobHandle::new(
-            job_id,
-            self.quantum_processor_id.clone(),
-            readout_map,
-        ))
+        Ok(JobHandle::new(job_id, job_target, readout_map))
     }
 
     pub(crate) async fn retrieve_results(
         &self,
-        job_id: JobId,
-        readout_mappings: HashMap<String, String>,
+        job_handle: &JobHandle,
     ) -> Result<ExecutionData, Error> {
         let response = retrieve_results(
-            job_id,
-            self.quantum_processor_id.as_ref(),
+            job_handle.job_id(),
+            job_handle.job_target(),
             self.client.as_ref(),
         )
         .await?;
 
         Ok(ExecutionData {
             result_data: ResultData::Qpu(QpuResultData::from_controller_mappings_and_values(
-                &readout_mappings,
+                job_handle.readout_map(),
                 &response.readout_values,
             )),
             duration: response

--- a/crates/python/qcs_sdk/_executable.pyi
+++ b/crates/python/qcs_sdk/_executable.pyi
@@ -49,35 +49,47 @@ class Executable:
         """
         ...
 
-    def execute_on_qpu(self, quantum_processor_id: str) -> ExecutionData:
+    def execute_on_qpu(self, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> ExecutionData:
         """
         Compile the program and execute it on a QPU, waiting for results.
+
+        :param endpoint_id: execute the compiled program against an explicitly provided endpoint. If `None`,
+        the default endpoint for the given quantum_processor_id is used.
 
         :raises ExecutionError: If the job fails to execute.
         """
         ...
 
-    async def execute_on_qpu_async(self, quantum_processor_id: str) -> ExecutionData:
+    async def execute_on_qpu_async(self, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> ExecutionData:
         """
         Compile the program and execute it on a QPU, waiting for results.
         (async analog of ``Executable.execute_on_qpu``)
 
+        :param endpoint_id: execute the compiled program against an explicitly provided endpoint. If `None`,
+        the default endpoint for the given quantum_processor_id is used.
+
         :raises ExecutionError: If the job fails to execute.
         """
         ...
 
-    def submit_to_qpu(self, quantum_processor_id: str) -> JobHandle:
+    def submit_to_qpu(self, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> JobHandle:
         """
         Compile the program and execute it on a QPU, without waiting for results.
 
+        :param endpoint_id: execute the compiled program against an explicitly provided endpoint. If `None`,
+        the default endpoint for the given quantum_processor_id is used.
+
         :raises ExecutionError: If the job fails to execute.
         """
         ...
 
-    async def submit_to_qpu_async(self, quantum_processor_id: str) -> JobHandle:
+    async def submit_to_qpu_async(self, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> JobHandle:
         """
         Compile the program and execute it on a QPU, without waiting for results.
         (async analog of ``Executable.execute_on_qpu``)
+
+        :param endpoint_id: execute the compiled program against an explicitly provided endpoint. If `None`,
+        the default endpoint for the given quantum_processor_id is used.
 
         :raises ExecutionError: If the job fails to execute.
         """

--- a/crates/python/src/executable.rs
+++ b/crates/python/src/executable.rs
@@ -171,22 +171,33 @@ impl PyExecutable {
         py_async!(py, py_submit_job!(self, quantum_processor_id))
     }
 
-    pub fn retrieve_results(&mut self, job_handle: PyJobHandle) -> PyResult<PyExecutionData> {
+    pub fn retrieve_results(
+        &mut self,
+        quantum_processor_id: String,
+        job_handle: PyJobHandle,
+    ) -> PyResult<PyExecutionData> {
         py_sync!(py_executable_data!(
             self,
             retrieve_results,
-            job_handle.into(),
+            quantum_processor_id,
+            &job_handle.into(),
         ))
     }
 
     pub fn retrieve_results_async<'py>(
         &'py mut self,
         py: Python<'py>,
+        quantum_processor_id: String,
         job_handle: PyJobHandle,
     ) -> PyResult<&PyAny> {
         py_async!(
             py,
-            py_executable_data!(self, retrieve_results, job_handle.into())
+            py_executable_data!(
+                self,
+                retrieve_results,
+                quantum_processor_id,
+                &job_handle.into()
+            )
         )
     }
 }
@@ -201,14 +212,14 @@ py_wrap_simple_enum! {
 }
 
 py_wrap_type! {
-    PyJobHandle(JobHandle<'static>) as "JobHandle";
+    PyJobHandle(JobHandle) as "JobHandle";
 }
 
 #[pymethods]
 impl PyJobHandle {
     #[getter]
-    pub fn job_id(&self) -> &str {
-        self.as_inner().job_id()
+    pub fn job_id(&self) -> String {
+        self.as_inner().job_id().to_string()
     }
 
     #[getter]

--- a/crates/python/src/executable.rs
+++ b/crates/python/src/executable.rs
@@ -70,14 +70,15 @@ macro_rules! py_executable_data {
     }};
 }
 
-/// Invoke `submit_to_qpu` on an executable.
-macro_rules! py_submit_job {
-    ($self: ident, $quantum_processor_id: expr) => {{
+/// Invoke a PyExecutable's inner Executable::method with given arguments,
+/// then mapped to `Future<Output = Result<PyJobHandle, ExecutionError>>`
+macro_rules! py_job_handle {
+    ($self: ident, $method: ident $(, $arg: expr)* $(,)?) => {{
         let arc = $self.as_inner().clone();
         async move {
             arc.lock()
                 .await
-                .submit_to_qpu($quantum_processor_id)
+                .$method($($arg),*)
                 .await
                 .map(JobHandle::from)
                 .map(PyJobHandle::from)
@@ -140,64 +141,110 @@ impl PyExecutable {
         py_async!(py, py_executable_data!(self, execute_on_qvm))
     }
 
-    pub fn execute_on_qpu(&self, quantum_processor_id: String) -> PyResult<PyExecutionData> {
-        py_sync!(py_executable_data!(
-            self,
-            execute_on_qpu,
-            quantum_processor_id,
-        ))
+    #[args(endpoint_id = "None")]
+    pub fn execute_on_qpu(
+        &self,
+        quantum_processor_id: String,
+        endpoint_id: Option<String>,
+    ) -> PyResult<PyExecutionData> {
+        match endpoint_id {
+            Some(endpoint_id) => py_sync!(py_executable_data!(
+                self,
+                execute_on_qpu_with_endpoint,
+                quantum_processor_id,
+                endpoint_id
+            )),
+            None => py_sync!(py_executable_data!(
+                self,
+                execute_on_qpu,
+                quantum_processor_id
+            )),
+        }
     }
 
+    #[args(endpoint_id = "None")]
     pub fn execute_on_qpu_async<'py>(
         &'py self,
         py: Python<'py>,
         quantum_processor_id: String,
+        endpoint_id: Option<String>,
     ) -> PyResult<&PyAny> {
-        py_async!(
-            py,
-            py_executable_data!(self, execute_on_qpu, quantum_processor_id)
-        )
+        match endpoint_id {
+            Some(endpoint_id) => py_async!(
+                py,
+                py_executable_data!(
+                    self,
+                    execute_on_qpu_with_endpoint,
+                    quantum_processor_id,
+                    endpoint_id
+                )
+            ),
+            None => py_async!(
+                py,
+                py_executable_data!(self, execute_on_qpu, quantum_processor_id)
+            ),
+        }
     }
 
-    pub fn submit_to_qpu(&self, quantum_processor_id: String) -> PyResult<PyJobHandle> {
-        py_sync!(py_submit_job!(self, quantum_processor_id))
+    #[args(endpoint_id = "None")]
+    pub fn submit_to_qpu(
+        &self,
+        quantum_processor_id: String,
+        endpoint_id: Option<String>,
+    ) -> PyResult<PyJobHandle> {
+        match endpoint_id {
+            Some(endpoint_id) => py_sync!(py_job_handle!(
+                self,
+                submit_to_qpu_with_endpoint,
+                quantum_processor_id,
+                endpoint_id
+            )),
+            None => py_sync!(py_job_handle!(self, submit_to_qpu, quantum_processor_id)),
+        }
     }
 
+    #[args(endpoint_id = "None")]
     pub fn submit_to_qpu_async<'py>(
         &'py self,
         py: Python<'py>,
         quantum_processor_id: String,
+        endpoint_id: Option<String>,
     ) -> PyResult<&PyAny> {
-        py_async!(py, py_submit_job!(self, quantum_processor_id))
+        match endpoint_id {
+            Some(endpoint_id) => {
+                py_async!(
+                    py,
+                    py_job_handle!(
+                        self,
+                        submit_to_qpu_with_endpoint,
+                        quantum_processor_id,
+                        endpoint_id
+                    )
+                )
+            }
+            None => py_async!(
+                py,
+                py_job_handle!(self, submit_to_qpu, quantum_processor_id)
+            ),
+        }
     }
 
-    pub fn retrieve_results(
-        &mut self,
-        quantum_processor_id: String,
-        job_handle: PyJobHandle,
-    ) -> PyResult<PyExecutionData> {
+    pub fn retrieve_results(&mut self, job_handle: PyJobHandle) -> PyResult<PyExecutionData> {
         py_sync!(py_executable_data!(
             self,
             retrieve_results,
-            quantum_processor_id,
-            &job_handle.into(),
+            job_handle.into()
         ))
     }
 
     pub fn retrieve_results_async<'py>(
         &'py mut self,
         py: Python<'py>,
-        quantum_processor_id: String,
         job_handle: PyJobHandle,
     ) -> PyResult<&PyAny> {
         py_async!(
             py,
-            py_executable_data!(
-                self,
-                retrieve_results,
-                quantum_processor_id,
-                &job_handle.into()
-            )
+            py_executable_data!(self, retrieve_results, job_handle.into())
         )
     }
 }
@@ -212,7 +259,7 @@ py_wrap_simple_enum! {
 }
 
 py_wrap_type! {
-    PyJobHandle(JobHandle) as "JobHandle";
+    PyJobHandle(JobHandle<'static>) as "JobHandle";
 }
 
 #[pymethods]

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -8,7 +8,7 @@ use pyo3::{
     types::{PyComplex, PyInt},
     Py, PyResult,
 };
-use qcs::qpu::client::GrpcClientError;
+use qcs::qpu::{api::JobTarget, client::GrpcClientError};
 use qcs_api_client_grpc::models::controller::{readout_values, ControllerJobExecutionResult};
 use rigetti_pyo3::{
     create_init_submodule, num_complex, py_wrap_error, py_wrap_union_enum, wrap_error,
@@ -61,12 +61,13 @@ py_function_sync_async! {
     /// * an RPCQ client cannot be built
     /// * the program cannot be submitted
     #[allow(clippy::implicit_hasher)]
-    #[pyfunction(client = "None")]
+    #[pyfunction(client = "None", endpoint_id = "None")]
     async fn submit(
         program: String,
         patch_values: HashMap<String, Vec<f64>>,
         quantum_processor_id: String,
         client: Option<PyQcsClient>,
+        endpoint_id: Option<String>,
     ) -> PyResult<String> {
         let client = PyQcsClient::get_or_create_client(client).await?;
 
@@ -83,7 +84,9 @@ py_function_sync_async! {
             .map_err(RustSubmissionError::from)
             .map_err(RustSubmissionError::to_py_err)?;
 
-        let job_id = qcs::qpu::api::submit(&quantum_processor_id, job, &patch_values, &client).await
+        let job_target = endpoint_id.map_or_else(|| JobTarget::QuantumProcessorId(quantum_processor_id), JobTarget::EndpointId);
+
+        let job_id = qcs::qpu::api::submit(&job_target, job, &patch_values, &client).await
             .map_err(RustSubmissionError::from)
             .map_err(RustSubmissionError::to_py_err)?;
 
@@ -179,15 +182,18 @@ impl From<ControllerJobExecutionResult> for ExecutionResults {
 }
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
+    #[pyfunction(client = "None", endpoint_id = "None")]
     async fn retrieve_results(
         job_id: String,
         quantum_processor_id: String,
         client: Option<PyQcsClient>,
+        endpoint_id: Option<String>,
     ) -> PyResult<ExecutionResults> {
         let client = PyQcsClient::get_or_create_client(client).await?;
 
-        let results = qcs::qpu::api::retrieve_results(job_id.into(), &quantum_processor_id, &client)
+        let job_target = endpoint_id.map_or_else(|| JobTarget::QuantumProcessorId(quantum_processor_id), JobTarget::EndpointId);
+
+        let results = qcs::qpu::api::retrieve_results(job_id.into(), &job_target, &client)
             .await
             .map_err(RustRetrieveResultsError::from)
             .map_err(RustRetrieveResultsError::to_py_err)?;


### PR DESCRIPTION
This is *one* solution to allowing `endpoint_id` to be provided when submitting a job, presented as a draft for discussion.

To consider, there is benefit in separating translation from submission, but if we keep all that functionality on `Execution` it's not straightforward to me how `Execution` would cache translation output between `submit`, or how it would be made clear that `translate` should be called before `submit`.