### PR TITLE
chore: fix cargo deny warning from hermit-abi conflicts

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -67,9 +67,7 @@ default = "deny"
 confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    { allow = ["MPL-2.0"], name = "webpki-roots", version = "*" },
-]
+exceptions = [{ allow = ["MPL-2.0"], name = "webpki-roots", version = "*" }]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
@@ -78,9 +76,7 @@ exceptions = [
 name = "ring"
 version = "*"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -96,7 +92,8 @@ wildcards = "deny"
 highlight = "all"
 skip-tree = [
     { name = "toml", version = "*", depth = 20 },
-    { name = "warp", version = "*", depth = 20 },  # Only used for development
+    { name = "warp", version = "*", depth = 20 },       # Only used for development
+    { name = "hermit-abi", version = "*", depth = 20 }, # Only used for development
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
See https://github.com/rigetti/qcs-sdk-rust/pull/203#issuecomment-1479739842

`simple_logger` still references the same version of `hermit-abi`, so that MR does not fix CI on main.