### PR TITLE
feat!: support HTTPS_PROXY and HTTP_PROXY client proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "async-socks5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
+dependencies = [
+ "async-trait",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +375,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +664,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +695,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-socks2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119e7612ab732dd10c43a3babbc75f212e9a8656c524fb1f85d0a7490c9cd5dd"
+dependencies = [
+ "async-socks5",
+ "futures",
+ "http",
+ "hyper",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +718,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -960,6 +1031,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,10 +1194,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "openssl"
+version = "0.10.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1457,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2f8560d8462749ccf01772ad8fc92999ecdf3bebe37b45ca7dc4838a834ae7"
+checksum = "7c08e260eb0f6d40b14e2c399df0be47de75ed0d829ca0f8e315df6df42fccf3"
 dependencies = [
  "async-trait",
  "dirs",
@@ -1474,12 +1602,15 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-grpc"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db289d73aa9a5bafb7f3c3029e52923da2005024e307750a8c30ef3a4a20a96a"
+checksum = "21638a5277a226914fe216c0b9f781a2755e482200625b6bd09a45f8192e30e2"
 dependencies = [
  "http",
  "http-body",
+ "hyper",
+ "hyper-proxy",
+ "hyper-socks2",
  "pbjson",
  "pbjson-build",
  "prost",
@@ -1490,13 +1621,14 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower",
+ "url",
 ]
 
 [[package]]
 name = "qcs-api-client-openapi"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44d3d778ba2ac173c19b15ee136f527cda67ed2ae3be642752937cee0851f02"
+checksum = "9ab4707aa6c0c154f6c313f01408b7a0a56c1c4282ca3db4d2e74dd496e80246"
 dependencies = [
  "qcs-api-client-common",
  "reqwest",
@@ -1656,6 +1788,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2153,6 +2286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2304,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2399,6 +2554,12 @@ checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 qcs-api = "0.2.1"
-qcs-api-client-common = "0.5.0"
-qcs-api-client-grpc = "0.5.0"
-qcs-api-client-openapi = "0.6.0"
+qcs-api-client-common = "0.6.0"
+qcs-api-client-grpc = "0.6.0"
+qcs-api-client-openapi = "0.7.0"
 quil-rs = "0.15"
 serde_json = "1.0.86"
 thiserror = "1.0.37"
@@ -21,4 +21,7 @@ numpy = "0.17"
 pyo3 = { version = "0.17", features = ["extension-module"] }
 pyo3-asyncio = { version = "0.17", features = ["tokio-runtime"] }
 pyo3-build-config = { version = "0.17" }
-rigetti-pyo3 = { version = "0.1.0-rc.4", features = ["extension-module", "complex"] }
+rigetti-pyo3 = { version = "0.1.0-rc.4", features = [
+    "extension-module",
+    "complex",
+] }

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -74,11 +74,10 @@ impl Qcs {
         quantum_processor_id: &str,
     ) -> Result<ControllerClient<RefreshService<Channel, ClientConfiguration>>, GrpcEndpointError>
     {
-        self.get_controller_endpoint(quantum_processor_id)
-            .await
-            .map(get_channel)
-            .map(|channel| wrap_channel_with(channel, self.get_config()))
-            .map(ControllerClient::new)
+        let uri = self.get_controller_endpoint(quantum_processor_id).await?;
+        let channel = get_channel(uri).map_err(|err| GrpcEndpointError::GrpcError(err.into()))?;
+        let service = wrap_channel_with(channel, self.get_config());
+        Ok(ControllerClient::new(service))
     }
 
     pub(crate) fn get_openapi_client(&self) -> OpenApiConfiguration {
@@ -101,10 +100,10 @@ impl Qcs {
         TranslationClient<RefreshService<Channel, ClientConfiguration>>,
         GrpcError<RefreshError>,
     > {
-        parse_uri(translation_grpc_endpoint)
-            .map(get_channel)
-            .map(|channel| wrap_channel_with(channel, self.get_config()))
-            .map(TranslationClient::new)
+        let uri = parse_uri(translation_grpc_endpoint)?;
+        let channel = get_channel(uri)?;
+        let service = wrap_channel_with(channel, self.get_config());
+        Ok(TranslationClient::new(service))
     }
 
     async fn get_controller_endpoint(
@@ -133,7 +132,7 @@ impl Qcs {
         let grpc_address = addresses.grpc.as_ref();
         grpc_address
             .ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.into()))
-            .map(|v| parse_uri(v).map_err(GrpcEndpointError::BadUri))?
+            .map(|v| parse_uri(v).map_err(GrpcEndpointError::GrpcError))?
     }
 
     /// Get address for Gateway assigned to the provided `quantum_processor_id`, if one exists.
@@ -165,16 +164,16 @@ impl Qcs {
         let target = gateways
             .first()
             .ok_or_else(|| GrpcEndpointError::NoEndpoint(quantum_processor_id.to_string()))?;
-        parse_uri(&target.url).map_err(GrpcEndpointError::BadUri)
+        parse_uri(&target.url).map_err(GrpcEndpointError::GrpcError)
     }
 }
 
 /// Errors that may occur while trying to resolve a `gRPC` endpoint
 #[derive(Debug, thiserror::Error)]
 pub enum GrpcEndpointError {
-    /// Error due to a malformed URI
-    #[error("Malformed URI for endpoint: {0}")]
-    BadUri(#[from] GrpcError<RefreshError>),
+    /// Error due to a bad gRPC configuration
+    #[error("Error configuring gRPC request: {0}")]
+    GrpcError(#[from] GrpcError<RefreshError>),
 
     /// Error due to failure to get endpoint for quantum processor
     #[error("Failed to get endpoint for quantum processor: {0}")]


### PR DESCRIPTION
Closes #238 

Route requests through client proxies via `HTTPS_PROXY` and `HTTP_PROXY` environment variables.

Supported protocols are `http`, `https`, and `socks5`.