### PR TITLE
fix(python): missing endpoint_id param added to api type annotations

### DIFF
--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -89,6 +89,7 @@ def submit(
     patch_values: Dict[str, List[float]],
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    endpoint_id: Optional[str] = None,
 ) -> str:
     """
     Submits an executable `program` to be run on the specified QPU.
@@ -97,6 +98,7 @@ def submit(
     :param patch_values: A mapping of symbols to their desired values (see `build_patch_values`).
     :param quantum_processor_id: The ID of the quantum processor to run the executable on.
     :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param endpoint_id: submit the program to an explicitly provided endpoint. If `None`, the default endpoint for the given quantum_processor_id is used.
 
     :returns: The ID of the submitted job which can be used to fetch results
 
@@ -111,6 +113,7 @@ async def submit_async(
     patch_values: Dict[str, List[float]],
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    endpoint_id: Optional[str] = None,
 ) -> str:
     """
     Submits an executable `program` to be run on the specified QPU.
@@ -120,6 +123,7 @@ async def submit_async(
     :param patch_values: A mapping of symbols to their desired values (see `build_patch_values`).
     :param quantum_processor_id: The ID of the quantum processor to run the executable on.
     :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param endpoint_id: submit the program to an explicitly provided endpoint. If `None`, the default endpoint for the given quantum_processor_id is used.
 
     :returns: The ID of the submitted job which can be used to fetch results
 
@@ -133,6 +137,7 @@ def retrieve_results(
     job_id: str,
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    endpoint_id: Optional[str] = None,
 ) -> ExecutionResults:
     """
     Fetches execution results for the given QCS Job ID.
@@ -140,6 +145,7 @@ def retrieve_results(
     :param job_id: The ID of the job to retrieve results for.
     :param quantum_processor_id: The ID of the quantum processor the job ran on.
     :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param endpoint_id: retrieve the results of a program submitted to an explicitly provided endpoint. If `None`, the default endpoint for the given quantum_processor_id is used.
 
     :returns: results from execution.
 
@@ -153,6 +159,7 @@ async def retrieve_results_async(
     job_id: str,
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    endpoint_id: Optional[str] = None,
 ) -> ExecutionResults:
     """
     Fetches execution results for the given QCS Job ID.
@@ -161,6 +168,7 @@ async def retrieve_results_async(
     :param job_id: The ID of the job to retrieve results for.
     :param quantum_processor_id: The ID of the quantum processor the job ran on.
     :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param endpoint_id: retrieve the results of a program submitted to an explicitly provided endpoint. If `None`, the default endpoint for the given quantum_processor_id is used.
 
     :returns: results from execution.
 


### PR DESCRIPTION
Accidentally missing from #262 