### PR TITLE
CI: Fix Release Pipelines

### DIFF
--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -36,4 +36,3 @@ jobs:
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
           path: './crates/lib'
-          dry-run: true

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
           path: './crates/lib'
+          dry-run: true

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -32,8 +32,4 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: katyo/publish-crates@v2
-        with:
-          registry-token: ${{ secrets.CRATES_IO_TOKEN }}
-          path: './crates/lib'
-          dry-run: true
+      - run: cargo publish --manifest-path=crates/lib/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }} --dry-run

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: is-lib-release
     env:
-      RUSTFLAGS: "-std=c++11"
+      CXXFLAGS: "-std=c++11"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - run: cargo publish --manifest-path=crates/lib/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }} --dry-run
+      - run: cargo publish --manifest-path=crates/lib/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - uses: katyo/publish-crates@v1
+      - uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
           path: './crates/lib'

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -16,6 +16,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: is-lib-release
+    env:
+      RUSTFLAGS: "-std=c++11"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,3 +36,4 @@ jobs:
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}
           path: './crates/lib'
+          dry-run: true

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -54,6 +54,8 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     needs: is-python-release
+    env:
+      RUSTFLAGS: "-std=c++11"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
@@ -86,17 +88,17 @@ jobs:
         name: wheels
         path: dist
 
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: [ macos, linux ]
-    steps:
-      - uses: actions/download-artifact@v3
-      - name: Publish to PyPi
-        env:
-          MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        uses: messense/maturin-action@v1
-        with:
-          command: upload 
-          args: --skip-existing wheels/*
+  # release:
+  #   name: Release
+  #   runs-on: ubuntu-latest
+  #   needs: [ macos, linux ]
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #     - name: Publish to PyPi
+  #       env:
+  #         MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
+  #         MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+  #       uses: messense/maturin-action@v1
+  #       with:
+  #         command: upload 
+  #         args: --skip-existing wheels/*

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: is-python-release
     env:
-      RUSTFLAGS: "-std=c++11"
+      CXXFLAGS: "-std=c++11"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -88,17 +88,17 @@ jobs:
         name: wheels
         path: dist
 
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   needs: [ macos, linux ]
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #     - name: Publish to PyPi
-  #       env:
-  #         MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
-  #         MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-  #       uses: messense/maturin-action@v1
-  #       with:
-  #         command: upload 
-  #         args: --skip-existing wheels/*
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ macos, linux ]
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish to PyPi
+        env:
+          MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        uses: messense/maturin-action@v1
+        with:
+          command: upload 
+          args: --skip-existing wheels/*

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -16,7 +16,7 @@ name = "qcs_sdk"
 crate-type = ["cdylib"]
 
 [dependencies]
-qcs = { path = "../lib" }
+qcs = { path = "../lib", version = "0.10.0-rc.21" }
 qcs-api.workspace = true
 qcs-api-client-common.workspace = true
 qcs-api-client-grpc.workspace = true

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -16,7 +16,7 @@ name = "qcs_sdk"
 crate-type = ["cdylib"]
 
 [dependencies]
-qcs = { path = "../lib", version = "*" }
+qcs = { path = "../lib" }
 qcs-api.workspace = true
 qcs-api-client-common.workspace = true
 qcs-api-client-grpc.workspace = true

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -16,7 +16,7 @@ name = "qcs_sdk"
 crate-type = ["cdylib"]
 
 [dependencies]
-qcs = { path = "../lib", version = "0.10.0-rc.21" }
+qcs = { path = "../lib", version = "*" }
 qcs-api.workspace = true
 qcs-api-client-common.workspace = true
 qcs-api-client-grpc.workspace = true


### PR DESCRIPTION
There were two main issues at play here.

For the library crate, the `katyo/publish-crates` action was outdated and didn't support workspace dependencies. ~Fixed by updating the action, I also had to explicitly set the version of `qcs` in the Python crate to get past a cargo error.~ Turned out to be easier to replace the action with a simple call to `cargo publish`.

For both the library crate and Python package, `zmq` was failing to build on linux without the `-std=c++11` flag. Fixed by setting the `CXXFLAGS` env variable for those build steps.

Here is an example of both pipelines passing with said fixes:

* [Release Rust](https://github.com/rigetti/qcs-sdk-rust/actions/runs/4835045064)
* [Release Python](https://github.com/rigetti/qcs-sdk-rust/actions/runs/4834900147)