### PR TITLE
feat: the default QCS Client configuration now respects environment variable overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytecount"
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159e0afbbe73e7118d1092b037929a2cebee4a7e19784cdeb1c029df4dbfa40a"
+checksum = "a83036b124a28d605c626560638a4d73da873922088574f1d0f14a1412840dad"
 dependencies = [
  "async-trait",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 
 [workspace.dependencies]
 qcs-api = "0.2.1"
-qcs-api-client-common = "0.6.1"
+qcs-api-client-common = "0.6.6"
 qcs-api-client-grpc = "0.6.1"
 qcs-api-client-openapi = "0.7.1"
 quil-rs = "0.15"

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -25,6 +25,9 @@ use qcs_api_client_openapi::models::QuantumProcessorAccessorType;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
+#[cfg(feature = "tracing")]
+use tracing;
+
 pub use qcs_api_client_common::configuration::LoadError;
 pub use qcs_api_client_grpc::channel::Error as GrpcError;
 pub use qcs_api_client_openapi::apis::Error as OpenApiError;
@@ -46,6 +49,13 @@ impl Qcs {
     pub async fn load() -> Result<Self, LoadError> {
         ClientConfiguration::load_default()
             .await
+            .or_else(|_| {
+                #[cfg(feature = "tracing")]
+                tracing::info!(
+                    "No QCS client configuration found, only generic QVMs will be accessible."
+                );
+                Ok(ClientConfiguration::default())
+            })
             .map(Self::with_config)
     }
 

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -25,9 +25,6 @@ use qcs_api_client_openapi::models::QuantumProcessorAccessorType;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
-#[cfg(feature = "tracing")]
-use tracing;
-
 pub use qcs_api_client_common::configuration::LoadError;
 pub use qcs_api_client_grpc::channel::Error as GrpcError;
 pub use qcs_api_client_openapi::apis::Error as OpenApiError;

--- a/crates/lib/src/qpu/client.rs
+++ b/crates/lib/src/qpu/client.rs
@@ -52,7 +52,7 @@ impl Qcs {
             .or_else(|_| {
                 #[cfg(feature = "tracing")]
                 tracing::info!(
-                    "No QCS client configuration found, only generic QVMs will be accessible."
+                    "No QCS client configuration found. QPU data and QCS will be inaccessible and only generic QVMs will be available for execution"
                 );
                 Ok(ClientConfiguration::default())
             })


### PR DESCRIPTION
As of `qcs-api-client-common` `0.6.6`, `ClientConfiguration` respects the value of environment variable overrides as the default value. Including these changes here allows users to initialize a default `QCSClient` that doesn't require a full blown QCS configuration but still uses overrides from the environment. This is useful for users who just want to use `quilc` and/or the `qvm`. They may not have a QCS config, but they still may set the `QCS_APPLICATIONS_QVM_URL` or `QCS_APPLICATIONS_QUILC_URL` environment variables and expect them to work.