### PR TITLE
fix(python): check signals before blocking thread

### DIFF
--- a/crates/python/src/executable.rs
+++ b/crates/python/src/executable.rs
@@ -135,8 +135,8 @@ impl PyExecutable {
         Self::from(Arc::new(Mutex::new(exe)))
     }
 
-    pub fn execute_on_qvm(&self) -> PyResult<PyExecutionData> {
-        py_sync!(py_executable_data!(self, execute_on_qvm))
+    pub fn execute_on_qvm(&self, py: Python<'_>) -> PyResult<PyExecutionData> {
+        py_sync!(py, py_executable_data!(self, execute_on_qvm))
     }
 
     pub fn execute_on_qvm_async<'py>(&'py self, py: Python<'py>) -> PyResult<&PyAny> {
@@ -154,14 +154,14 @@ impl PyExecutable {
         let translation_options =
             Option::<TranslationOptions>::py_try_from(py, &translation_options)?;
         match endpoint_id {
-            Some(endpoint_id) => py_sync!(py_executable_data!(
+            Some(endpoint_id) => py_sync!(py, py_executable_data!(
                 self,
                 execute_on_qpu_with_endpoint,
                 quantum_processor_id,
                 endpoint_id,
                 translation_options,
             )),
-            None => py_sync!(py_executable_data!(
+            None => py_sync!(py, py_executable_data!(
                 self,
                 execute_on_qpu,
                 quantum_processor_id,
@@ -214,14 +214,14 @@ impl PyExecutable {
         let translation_options =
             Option::<TranslationOptions>::py_try_from(py, &translation_options)?;
         match endpoint_id {
-            Some(endpoint_id) => py_sync!(py_job_handle!(
+            Some(endpoint_id) => py_sync!(py, py_job_handle!(
                 self,
                 submit_to_qpu_with_endpoint,
                 quantum_processor_id,
                 endpoint_id,
                 translation_options,
             )),
-            None => py_sync!(py_job_handle!(
+            None => py_sync!(py, py_job_handle!(
                 self,
                 submit_to_qpu,
                 quantum_processor_id,
@@ -265,8 +265,8 @@ impl PyExecutable {
         }
     }
 
-    pub fn retrieve_results(&mut self, job_handle: PyJobHandle) -> PyResult<PyExecutionData> {
-        py_sync!(py_executable_data!(
+    pub fn retrieve_results(&mut self, py: Python<'_>, job_handle: PyJobHandle) -> PyResult<PyExecutionData> {
+        py_sync!(py, py_executable_data!(
             self,
             retrieve_results,
             job_handle.into()

--- a/crates/python/src/py_sync.rs
+++ b/crates/python/src/py_sync.rs
@@ -22,11 +22,15 @@ macro_rules! py_sync {
     ($py: ident, $body: expr) => {{
         let runtime = ::pyo3_asyncio::tokio::get_runtime();
         let handle = runtime.spawn($body);
+
+        // A 100ms loop delay is a bit arbitrary, but seems to
+        // balance CPU usage and SIGINT responsiveness well enough.
         let delay = ::std::time::Duration::from_millis(100);
         while !handle.is_finished() {
             $py.check_signals()?;
             ::std::thread::sleep(delay);
         }
+
         runtime
             .block_on(handle)
             .map_err(|err| ::pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?

--- a/crates/python/src/py_sync.rs
+++ b/crates/python/src/py_sync.rs
@@ -19,9 +19,14 @@
 /// assert say_hello("Rigetti") == "hello Rigetti"
 /// ```
 macro_rules! py_sync {
-    ($body: expr) => {{
+    ($py: ident, $body: expr) => {{
         let runtime = ::pyo3_asyncio::tokio::get_runtime();
         let handle = runtime.spawn($body);
+        let delay = ::std::time::Duration::from_millis(100);
+        while !handle.is_finished() {
+            $py.check_signals()?;
+            ::std::thread::sleep(delay);
+        }
         runtime
             .block_on(handle)
             .map_err(|err| ::pyo3::exceptions::PyRuntimeError::new_err(err.to_string()))?
@@ -82,8 +87,8 @@ macro_rules! py_function_sync_async {
         ::paste::paste! {
         $(#[$meta])+
         #[pyo3(name = $name "")]
-        pub fn [< py_ $name >]($($arg: $kind),*) $(-> $ret)? {
-            $crate::py_sync::py_sync!($name($($arg),*))
+        pub fn [< py_ $name >](py: ::pyo3::Python<'_> $(, $arg: $kind)*) $(-> $ret)? {
+            $crate::py_sync::py_sync!(py, $name($($arg),*))
         }
 
         $(#[$meta])+

--- a/crates/python/src/qpu/client.rs
+++ b/crates/python/src/qpu/client.rs
@@ -183,8 +183,8 @@ impl PyQcsClient {
     #[staticmethod]
     #[args("/", profile_name = "None", use_gateway = "None")]
     #[pyo3(name = "load")]
-    pub fn py_load(profile_name: Option<String>, use_gateway: Option<bool>) -> PyResult<Self> {
-        py_sync!(Self::load(profile_name, use_gateway))
+    pub fn py_load(py: Python<'_>, profile_name: Option<String>, use_gateway: Option<bool>) -> PyResult<Self> {
+        py_sync!(py, Self::load(profile_name, use_gateway))
     }
 
     #[staticmethod]


### PR DESCRIPTION
Fixes https://github.com/rigetti/qcs-sdk-rust/issues/283

Instead of blocking on a spawned thread, continually check the thread status and `py.check_signals`. Only block the main thread when the spawned thread is ready.

The async counterpart functions already support `Ctrl-C`.

To test this, run the following without having quil-c running (so that requests hang):
```sh
cd crates/python
poetry shell
maturin develop
python -m asyncio
```
and then in the python shell, try both of these
```py
from qcs_sdk.compiler.quilc import get_version_info, get_version_info_async

get_version_info()
await get_version_info_async()
```

Originally this was paired with an update to make the zmq client async, but that isn't actually necessary.