### PR TITLE
feat(python): support TranslationOptions

### DIFF
--- a/crates/python/qcs_sdk/grpc/models/translation.pyi
+++ b/crates/python/qcs_sdk/grpc/models/translation.pyi
@@ -1,0 +1,45 @@
+from typing import Optional, final
+
+class TranslationOptions:
+    translation_backend: Optional[TranslationBackend] = None
+
+    ...
+
+@final
+class TranslationBackend:
+    """
+    Object specifying which translation backend to use to translate a particular program,
+    and for that given backend, what options to apply.
+
+    Variants:
+        ``v1``: Corresponds to the V1 translation backend.
+        ``v2``: Corresponds to the V2 translation backend.
+
+    Methods (each per variant):
+        - ``is_*``: if the underlying values are that type.
+        - ``as_*``: if the underlying values are that type, then those values, otherwise ``None``.
+        - ``to_*``: the underlying values as that type, raises ``ValueError`` if they are not.
+        - ``from_*``: wrap underlying values as this enum type.
+
+    """
+
+    def is_v1(self) -> bool: ...
+    def is_v2(self) -> bool: ...
+    def as_v1(self) -> Optional[BackendV1Options]: ...
+    def as_v2(self) -> Optional[BackendV2Options]: ...
+    def to_v1(self) -> BackendV1Options: ...
+    def to_v2(self) -> BackendV2Options: ...
+    @staticmethod
+    def from_v1(inner: BackendV1Options) -> "TranslationBackend": ...
+    @staticmethod
+    def from_v2(inner: BackendV2Options) -> "TranslationBackend": ...
+
+class BackendV1Options:
+    """
+    Options for the V1 translation backend.
+    """
+
+class BackendV2Options:
+    """
+    Options for the V2 translation backend.
+    """

--- a/crates/python/qcs_sdk/qpu/translation.pyi
+++ b/crates/python/qcs_sdk/qpu/translation.pyi
@@ -1,6 +1,7 @@
 from typing import Dict, Optional, final
 
 from qcs_sdk.client import QCSClient
+from qcs_sdk.grpc.models.translation import TranslationOptions
 
 class GetQuiltCalibrationsError(RuntimeError):
     """An error occured while fetching Quil-T calibrations."""
@@ -88,6 +89,7 @@ def translate(
     num_shots: int,
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    translation_options: Optional[TranslationOptions] = None,
 ) -> TranslationResult:
     """
     Translates a native Quil program into an executable program.
@@ -109,6 +111,7 @@ async def translate_async(
     num_shots: int,
     quantum_processor_id: str,
     client: Optional[QCSClient] = None,
+    translation_options: Optional[TranslationOptions] = None,
 ) -> TranslationResult:
     """
     Translates a native Quil program into an executable program.

--- a/crates/python/src/grpc/mod.rs
+++ b/crates/python/src/grpc/mod.rs
@@ -1,1 +1,9 @@
+use rigetti_pyo3::create_init_submodule;
+
 pub mod models;
+
+create_init_submodule! {
+    submodules: [
+        "models": models::init_submodule
+    ],
+}

--- a/crates/python/src/grpc/models/mod.rs
+++ b/crates/python/src/grpc/models/mod.rs
@@ -1,2 +1,10 @@
+use rigetti_pyo3::create_init_submodule;
+
 pub mod controller;
 pub mod translation;
+
+create_init_submodule! {
+    submodules: [
+        "translation": translation::init_submodule
+    ],
+}

--- a/crates/python/src/grpc/models/translation.rs
+++ b/crates/python/src/grpc/models/translation.rs
@@ -1,7 +1,7 @@
 use qcs_api_client_grpc::services::translation::{
     translation_options::TranslationBackend, BackendV1Options, BackendV2Options, TranslationOptions,
 };
-use rigetti_pyo3::{py_wrap_data_struct, py_wrap_type, py_wrap_union_enum};
+use rigetti_pyo3::{py_wrap_data_struct, py_wrap_type, py_wrap_union_enum, create_init_submodule};
 
 py_wrap_type! {
     #[derive(Default)]
@@ -25,4 +25,13 @@ py_wrap_data_struct! {
     PyTranslationOptions(TranslationOptions) as "TranslationOptions" {
         translation_backend: Option<TranslationBackend> => Option<PyTranslationBackend>
     }
+}
+
+create_init_submodule! {
+    classes: [
+        PyTranslationBackend,
+        PyTranslationOptions,
+        PyBackendV1Options,
+        PyBackendV2Options
+    ],
 }


### PR DESCRIPTION
Closes #306
Closes #281 

* Adds Python type stubs
* Fixes outdated python type stub for `translate`
* Builds the `grpc` module into Python bindings

TODO:

- [ ] `grpc/controller`. Will add that once I know these changes are on the right track