### PR TITLE
feat!: QVM timeout can now be configured via a new options parameter

### DIFF
--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -679,7 +679,9 @@ impl From<ExecutionError> for Error {
 impl From<qvm::Error> for Error {
     fn from(err: qvm::Error) -> Self {
         match err {
-            qvm::Error::QvmCommunication { .. } => Self::Connection(Service::Qvm),
+            qvm::Error::QvmCommunication { .. } | qvm::Error::Client { .. } => {
+                Self::Connection(Service::Qvm)
+            }
             qvm::Error::Parsing(_)
             | qvm::Error::ShotsMustBePositive
             | qvm::Error::RegionSizeMismatch { .. }

--- a/crates/lib/src/qvm/execution.rs
+++ b/crates/lib/src/qvm/execution.rs
@@ -7,6 +7,7 @@ use crate::{executable::Parameters, qvm::run_program};
 
 use crate::client::Qcs;
 
+use super::QvmOptions;
 use super::{api::AddressRequest, Error, QvmResultData};
 
 /// Contains all the info needed to execute on a QVM a single time, with the ability to be reused for
@@ -69,6 +70,7 @@ impl Execution {
             None,
             None,
             client,
+            &QvmOptions::default(),
         )
         .await
     }

--- a/crates/lib/src/qvm/mod.rs
+++ b/crates/lib/src/qvm/mod.rs
@@ -20,7 +20,7 @@ pub mod api;
 mod execution;
 
 /// Number of seconds to wait before timing out.
-const DEFAULT_QVM_TIMEOUT: f32 = 30.0;
+const DEFAULT_QVM_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Encapsulates data returned after running a program on the QVM
 #[allow(clippy::module_name_repetitions)]
@@ -175,7 +175,7 @@ impl QvmOptions {
 impl Default for QvmOptions {
     fn default() -> Self {
         Self {
-            timeout: Some(Duration::from_secs_f32(DEFAULT_QVM_TIMEOUT)),
+            timeout: Some(DEFAULT_QVM_TIMEOUT),
         }
     }
 }

--- a/crates/lib/src/qvm/mod.rs
+++ b/crates/lib/src/qvm/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains all the functionality for running Quil programs on a QVM. Specifically,
 //! the [`Execution`] struct in this module.
 
-use std::{collections::HashMap, num::NonZeroU16, str::FromStr};
+use std::{collections::HashMap, num::NonZeroU16, str::FromStr, time::Duration};
 
 use quil_rs::{
     instruction::{ArithmeticOperand, Instruction, MemoryReference, Move},
@@ -18,6 +18,9 @@ use self::api::AddressRequest;
 
 pub mod api;
 mod execution;
+
+/// Number of seconds to wait before timing out.
+const DEFAULT_QVM_TIMEOUT: f32 = 30.0;
 
 /// Encapsulates data returned after running a program on the QVM
 #[allow(clippy::module_name_repetitions)]
@@ -52,6 +55,7 @@ pub async fn run(
     gate_noise: Option<(f64, f64, f64)>,
     rng_seed: Option<i64>,
     client: &Qcs,
+    options: &QvmOptions,
 ) -> Result<QvmResultData, Error> {
     #[cfg(feature = "tracing")]
     tracing::debug!("parsing a program to be executed on the qvm");
@@ -65,6 +69,7 @@ pub async fn run(
         gate_noise,
         rng_seed,
         client,
+        options,
     )
     .await
 }
@@ -81,6 +86,7 @@ pub async fn run_program(
     gate_noise: Option<(f64, f64, f64)>,
     rng_seed: Option<i64>,
     client: &Qcs,
+    options: &QvmOptions,
 ) -> Result<QvmResultData, Error> {
     #[cfg(feature = "tracing")]
     tracing::debug!(
@@ -98,7 +104,7 @@ pub async fn run_program(
         gate_noise,
         rng_seed,
     );
-    api::run(&request, client)
+    api::run(&request, client, options)
         .await
         .map(|response| QvmResultData::from_memory_map(response.registers))
 }
@@ -147,6 +153,33 @@ pub fn apply_parameters_to_program(
     Ok(program)
 }
 
+/// Options avaialable for running programs on the QVM.
+#[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Copy, Debug)]
+pub struct QvmOptions {
+    /// The timeout to use for requests to the QVM. If set to [`None`], there is no timeout.
+    pub timeout: Option<Duration>,
+}
+
+impl QvmOptions {
+    /// Builds a [`QvmOptions`] with the zero value for each option.
+    ///
+    /// Consider using [`Default`] to get a reasonable set of
+    /// configuration options as a starting point.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { timeout: None }
+    }
+}
+
+impl Default for QvmOptions {
+    fn default() -> Self {
+        Self {
+            timeout: Some(Duration::from_secs_f32(DEFAULT_QVM_TIMEOUT)),
+        }
+    }
+}
+
 /// All of the errors that can occur when running a Quil program on QVM.
 #[allow(missing_docs)]
 #[derive(Debug, thiserror::Error)]
@@ -170,6 +203,8 @@ pub enum Error {
     },
     #[error("QVM reported a problem running your program: {message}")]
     Qvm { message: String },
+    #[error("The client failed to make the request: {0}")]
+    Client(#[from] reqwest::Error),
 }
 
 #[cfg(test)]

--- a/crates/lib/tests/qvm_api.rs
+++ b/crates/lib/tests/qvm_api.rs
@@ -3,7 +3,10 @@
 
 use std::{collections::HashMap, num::NonZeroU16};
 
-use qcs::{client::Qcs, qvm::api};
+use qcs::{
+    client::Qcs,
+    qvm::{api, QvmOptions},
+};
 use regex::Regex;
 
 const PROGRAM: &str = r##"
@@ -16,7 +19,7 @@ MEASURE 1 ro[1]
 
 #[tokio::test]
 async fn test_get_version_info() {
-    let version = api::get_version_info(&Qcs::default())
+    let version = api::get_version_info(&Qcs::default(), &QvmOptions::default())
         .await
         .expect("Should be able to get version info.");
     let semver_re = Regex::new(r"^([0-9]+)\.([0-9]+)\.([0-9]+)").unwrap();
@@ -34,7 +37,7 @@ async fn test_run() {
         Some((0.1, 0.5, 0.4)),
         Some(1),
     );
-    let response = api::run(&request, &client)
+    let response = api::run(&request, &client, &QvmOptions::default())
         .await
         .expect("Should be able to run");
     assert_eq!(response.registers.len(), 1);
@@ -57,7 +60,7 @@ async fn test_run_and_measure() {
         Some((0.1, 0.5, 0.4)),
         Some(1),
     );
-    let qubits = api::run_and_measure(&request, &client)
+    let qubits = api::run_and_measure(&request, &client, &QvmOptions::default())
         .await
         .expect("Should be able to run and measure");
     assert_eq!(qubits.len(), 5);
@@ -75,7 +78,7 @@ Z 2
     let operators = vec!["X 0\nY 1\n".to_string(), "Z 2\n".to_string()];
     let request = api::ExpectationRequest::new(prep_program.to_string(), &operators, None);
 
-    let expectations = api::measure_expectation(&request, &client)
+    let expectations = api::measure_expectation(&request, &client, &QvmOptions::default())
         .await
         .expect("Should be able to measure expectation");
 
@@ -86,7 +89,7 @@ Z 2
 async fn test_get_wavefunction() {
     let client = Qcs::default();
     let request = api::WavefunctionRequest::new(PROGRAM.to_string(), None, None, Some(0));
-    api::get_wavefunction(&request, &client)
+    api::get_wavefunction(&request, &client, &QvmOptions::default())
         .await
         .expect("Should be able to get wavefunction");
 }

--- a/crates/python/qcs_sdk/qvm/__init__.pyi
+++ b/crates/python/qcs_sdk/qvm/__init__.pyi
@@ -26,6 +26,30 @@ class QVMResultData:
         ...
 
 @final
+class QVMOptions:
+    """
+    Options avaialable for running programs on the QVM.
+    """
+
+    def __new__(cls, timeout_seconds: Optional[float] = None) -> QVMOptions: ...
+    @staticmethod
+    def default() -> QVMOptions:
+        """Get the default set of ``QVMOptions`` used for QVM requests.
+
+        Settings:
+            timeout: 30.0 seconds
+        """
+        ...
+    @property
+    def timeout(cls):
+        """The timeout used for reqeusts to the QVM. If set to none, there is no timeout."""
+        ...
+    @timeout.setter
+    def timeout(cls, timeout: Optional[float]):
+        """The timeout used for reqeusts to the QVM. If set to none, there is no timeout."""
+        ...
+
+@final
 class QVMError(RuntimeError):
     """
     Errors that can occur when running a Quil program on the QVM.
@@ -42,6 +66,7 @@ def run(
     gate_noise: Optional[Tuple[float, float, float]] = None,
     rng_seed: Optional[int] = None,
     client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> QVMResultData:
     """
     Runs the given program on the QVM.
@@ -51,6 +76,7 @@ def run(
     :param addresses: A mapping of memory region names to an ``AddressRequest`` describing what data to get back for that memory region from the QVM at the end of execution.
     :param params: A mapping of memory region names to their desired values.
     :param client: An optional ``QCSClient`` to use. If unset, creates one using the environemnt configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
 
     :returns: A ``QVMResultData`` containing the final state of of memory for the requested readouts after the program finished running.
 
@@ -67,6 +93,7 @@ async def run_async(
     gate_noise: Optional[Tuple[float, float, float]] = None,
     rng_seed: Optional[int] = None,
     client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> QVMResultData:
     """
     Asynchronously runs the given program on the QVM.
@@ -76,6 +103,7 @@ async def run_async(
     :param addresses: A mapping of memory region names to an ``AddressRequest`` describing what data to get back for that memory region from the QVM at the end of execution.
     :param params: A mapping of memory region names to their desired values.
     :param client: An optional ``QCSClient`` to use. If unset, creates one using the environemnt configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
 
     :returns: A ``QVMResultData`` containing the final state of of memory for the requested readouts after the program finished running.
 

--- a/crates/python/qcs_sdk/qvm/api.pyi
+++ b/crates/python/qcs_sdk/qvm/api.pyi
@@ -3,10 +3,16 @@ from typing_extensions import Self
 
 from qcs_sdk import RegisterData
 from qcs_sdk.client import QCSClient
+from qcs_sdk.qvm import QVMOptions
 
-def get_version_info(client: Optional[QCSClient] = None) -> str:
+def get_version_info(
+    client: Optional[QCSClient] = None, options: Optional[QVMOptions] = None
+) -> str:
     """
     Gets version information from the running QVM server.
+
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
 
     :returns: The QVM version as a string
 
@@ -14,9 +20,14 @@ def get_version_info(client: Optional[QCSClient] = None) -> str:
     """
     ...
 
-async def get_version_info_async(client: Optional[QCSClient] = None) -> str:
+async def get_version_info_async(
+    client: Optional[QCSClient] = None, options: Optional[QVMOptions] = None
+) -> str:
     """
     Asynchronously gets version information from the running QVM server.
+
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
 
     :returns: The QVM version as a string
 
@@ -97,15 +108,30 @@ class MultishotResponse:
     def registers(self, value: Mapping[str, RegisterData]): ...
 
 def run(
-    request: MultishotRequest, client: Optional[QCSClient] = None
+    request: MultishotRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> MultishotResponse:
-    """Executes a program on the QVM"""
+    """Executes a program on the QVM
+
+    :param request: The ``MultishotRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+
+    """
     ...
 
 def run_async(
-    request: MultishotRequest, client: Optional[QCSClient] = None
+    request: MultishotRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> MultishotResponse:
-    """Executes a program on the QVM"""
+    """Executes a program on the QVM
+
+    :param request: The ``MultishotRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+    """
     ...
 
 @final
@@ -178,15 +204,31 @@ class ExpectationRequest:
     def rng_seed(self, value: Optional[int]): ...
 
 def measure_expectation(
-    request: ExpectationRequest, client: Optional[QCSClient] = None
+    request: ExpectationRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> List[float]:
-    """Executes a program on the QVM, measuring and returning the expectation value of the given Pauli operators using a prepared state."""
+    """
+    Executes a program on the QVM, measuring and returning the expectation value of the given Pauli operators using a prepared state.
+
+    :param request: The ``ExpectationRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+    """
     ...
 
 def measure_expectation_async(
-    request: ExpectationRequest, client: Optional[QCSClient] = None
+    request: ExpectationRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> List[float]:
-    """Executes a program on the QVM, measuring and returning the expectation value of the given Pauli operators using a prepared state."""
+    """
+    Executes a program on the QVM, measuring and returning the expectation value of the given Pauli operators using a prepared state.
+
+    :param request: The ``ExpectationRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+    """
     ...
 
 @final
@@ -218,13 +260,29 @@ class WavefunctionRequest:
     def rng_seed(self, value: Optional[int]): ...
 
 def get_wavefunction(
-    request: WavefunctionRequest, client: Optional[QCSClient] = None
+    request: WavefunctionRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> bytes:
-    """Executes a program on the QVM, returning the resulting wavefunction."""
+    """
+    Executes a program on the QVM, returning the resulting wavefunction.
+
+    :param request: The ``WavefunctionRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+    """
     ...
 
 def get_wavefunction_async(
-    request: WavefunctionRequest, client: Optional[QCSClient] = None
+    request: WavefunctionRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> List[int]:
-    """Executes a program on the QVM, returning the resulting list of bytes."""
+    """
+    Executes a program on the QVM, returning the resulting wavefunction.
+
+    :param request: The ``WavefunctionRequest`` to use.
+    :param client: An optional ``QCSClient`` to use. If unset, creates one using the environment configuration (see https://docs.rigetti.com/qcs/references/qcs-client-configuration).
+    :param options: An optional ``QVMOptions`` to use. If unset, uses ``QVMOptions.default()`` for the request.
+    """
     ...

--- a/crates/python/src/qvm/api.rs
+++ b/crates/python/src/qvm/api.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, num::NonZeroU16};
 
-use super::RustQvmError;
+use super::{PyQvmOptions, RustQvmError};
 use crate::{client::PyQcsClient, py_sync::py_function_sync_async, register_data::PyRegisterData};
 
 use pyo3::{
@@ -45,10 +45,10 @@ create_init_submodule! {
 }
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
-    async fn get_version_info(client: Option<PyQcsClient>) -> PyResult<String> {
+    #[pyfunction]
+    async fn get_version_info(client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<String> {
         let client = PyQcsClient::get_or_create_client(client).await;
-        qcs::qvm::api::get_version_info(&client)
+        qcs::qvm::api::get_version_info(&client, options.unwrap_or_default().as_inner())
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)
@@ -132,15 +132,17 @@ py_wrap_data_struct! {
         registers: HashMap<String, RegisterData> => HashMap<String, PyRegisterData>
     }
 }
+impl_repr!(PyMultishotResponse);
 
 py_function_sync_async! {
     #[pyfunction(client = "None")]
     async fn run(
         request: PyMultishotRequest,
         client: Option<PyQcsClient>,
+        options: Option<PyQvmOptions>,
     ) -> PyResult<PyMultishotResponse> {
         let client = PyQcsClient::get_or_create_client(client).await;
-        qcs::qvm::api::run(request.as_inner(), &client)
+        qcs::qvm::api::run(request.as_inner(), &client, options.unwrap_or_default().as_inner())
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)
@@ -195,10 +197,10 @@ impl PyMultishotMeasureRequest {
 }
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
-    async fn run_and_measure(request: PyMultishotMeasureRequest, client: Option<PyQcsClient>) -> PyResult<Vec<Vec<i64>>> {
+    #[pyfunction]
+    async fn run_and_measure(request: PyMultishotMeasureRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<Vec<i64>>> {
         let client = PyQcsClient::get_or_create_client(client).await;
-        qcs::qvm::api::run_and_measure(request.as_inner(), &client)
+        qcs::qvm::api::run_and_measure(request.as_inner(), &client, options.unwrap_or_default().as_inner())
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)
@@ -227,10 +229,10 @@ impl PyExpectationRequest {
 }
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
-    async fn measure_expectation(request: PyExpectationRequest, client: Option<PyQcsClient>) -> PyResult<Vec<f64>> {
+    #[pyfunction]
+    async fn measure_expectation(request: PyExpectationRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<f64>> {
         let client = PyQcsClient::get_or_create_client(client).await;
-        qcs::qvm::api::measure_expectation(request.as_inner(), &client)
+        qcs::qvm::api::measure_expectation(request.as_inner(), &client, options.unwrap_or_default().as_inner())
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)
@@ -267,9 +269,9 @@ impl PyWavefunctionRequest {
 
 py_function_sync_async! {
     #[pyfunction(client = "None")]
-    async fn get_wavefunction(request: PyWavefunctionRequest, client: Option<PyQcsClient>) -> PyResult<Vec<u8>> {
+    async fn get_wavefunction(request: PyWavefunctionRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<u8>> {
         let client = PyQcsClient::get_or_create_client(client).await;
-        qcs::qvm::api::get_wavefunction(request.as_inner(), &client)
+        qcs::qvm::api::get_wavefunction(request.as_inner(), &client, options.unwrap_or_default().as_inner())
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)

--- a/crates/python/src/qvm/mod.rs
+++ b/crates/python/src/qvm/mod.rs
@@ -1,11 +1,14 @@
-use qcs::{qvm::QvmResultData, RegisterData};
-use rigetti_pyo3::{
-    create_init_submodule, py_wrap_error, py_wrap_type,
-    pyo3::{exceptions::PyRuntimeError, prelude::*, Python},
-    wrap_error, PyTryFrom, PyWrapper, ToPython, ToPythonError,
+use qcs::{
+    qvm::{QvmOptions, QvmResultData},
+    RegisterData,
 };
-use std::collections::HashMap;
+use rigetti_pyo3::{
+    create_init_submodule, impl_as_mut_for_wrapper, impl_repr, py_wrap_error, py_wrap_type,
+    pyo3::{exceptions::PyRuntimeError, prelude::*, Python},
+    wrap_error, PyTryFrom, PyWrapper, PyWrapperMut, ToPython, ToPythonError,
+};
 use std::num::NonZeroU16;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{client::PyQcsClient, py_sync::py_function_sync_async, register_data::PyRegisterData};
 
@@ -21,7 +24,7 @@ py_wrap_type! {
 }
 
 create_init_submodule! {
-    classes: [PyQvmResultData],
+    classes: [PyQvmResultData, PyQvmOptions],
     errors: [QVMError],
     funcs: [py_run, py_run_async],
     submodules: [
@@ -47,6 +50,42 @@ impl PyQvmResultData {
     }
 }
 
+py_wrap_type! {
+    #[derive(Default)]
+    PyQvmOptions(QvmOptions) as "QVMOptions"
+}
+impl_as_mut_for_wrapper!(PyQvmOptions);
+impl_repr!(PyQvmOptions);
+
+#[pymethods]
+impl PyQvmOptions {
+    #[new]
+    #[args("/", timeout_seconds = "30.0")]
+    pub fn new(timeout_seconds: Option<f64>) -> Self {
+        Self(QvmOptions {
+            timeout: timeout_seconds.map(Duration::from_secs_f64),
+        })
+    }
+
+    #[getter]
+    pub fn timeout(&self) -> Option<f32> {
+        self.as_inner()
+            .timeout
+            .map(|duration| duration.as_secs_f32())
+    }
+
+    #[setter]
+    pub fn set_timeout(&mut self, timeout_seconds: Option<f64>) {
+        self.as_inner_mut().timeout = timeout_seconds.map(Duration::from_secs_f64);
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "default")]
+    pub fn py_default() -> Self {
+        <Self as Default>::default()
+    }
+}
+
 py_function_sync_async! {
     #[pyfunction]
     async fn run(
@@ -59,11 +98,25 @@ py_function_sync_async! {
         gate_noise: Option<(f64, f64, f64)>,
         rng_seed: Option<i64>,
         client: Option<PyQcsClient>,
+        options: Option<PyQvmOptions>,
     ) -> PyResult<PyQvmResultData> {
         let client = PyQcsClient::get_or_create_client(client).await;
         let params = params.into_iter().map(|(key, value)| (key.into_boxed_str(), value)).collect();
         let addresses = addresses.into_iter().map(|(address, request)| (address, request.as_inner().clone())).collect();
-        Ok(PyQvmResultData(qcs::qvm::run(&quil, shots, addresses, &params, measurement_noise, gate_noise, rng_seed, &client)
+        let options = options.unwrap_or_default();
+        Ok(
+            PyQvmResultData(
+                qcs::qvm::run(
+                    &quil,
+                    shots,
+                    addresses,
+                    &params,
+                    measurement_noise,
+                    gate_noise,
+                    rng_seed,
+                    &client,
+                    options.as_inner()
+            )
             .await
             .map_err(RustQvmError::from)
             .map_err(RustQvmError::to_py_err)?))


### PR DESCRIPTION
There wasn't a good way to set a timeout on QVM requests, so I created an options struct, similar to how we handle it for quilc.

