### PR TITLE
feat(python): Integrate with logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "async-socks5"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1684,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-log"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c94ff6535a6bae58d7d0b85e60d4c53f7f84d0d0aa35d6a28c3f3e70bfe51444"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
+]
+
+[[package]]
 name = "pyo3-macros"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1849,7 @@ dependencies = [
  "pyo3",
  "pyo3-asyncio",
  "pyo3-build-config",
+ "pyo3-log",
  "qcs",
  "qcs-api",
  "qcs-api-client-common",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -11,9 +11,23 @@ readme = "./README.md"
 
 [features]
 manual-tests = []
-tracing = ["dep:tracing", "qcs-api-client-common/tracing", "qcs-api-client-grpc/tracing", "qcs-api-client-openapi/tracing"]
-tracing-config = ["tracing", "qcs-api-client-common/tracing-config", "qcs-api-client-grpc/tracing-config", "qcs-api-client-openapi/tracing-config"]
-otel-tracing = ["tracing-config", "qcs-api-client-grpc/otel-tracing", "qcs-api-client-openapi/otel-tracing"]
+tracing = [
+  "dep:tracing",
+  "qcs-api-client-common/tracing",
+  "qcs-api-client-grpc/tracing",
+  "qcs-api-client-openapi/tracing",
+]
+tracing-config = [
+  "tracing",
+  "qcs-api-client-common/tracing-config",
+  "qcs-api-client-grpc/tracing-config",
+  "qcs-api-client-openapi/tracing-config",
+]
+otel-tracing = [
+  "tracing-config",
+  "qcs-api-client-grpc/otel-tracing",
+  "qcs-api-client-openapi/otel-tracing",
+]
 
 [dependencies]
 dirs = "5.0.0"
@@ -28,14 +42,17 @@ qcs-api-client-common.workspace = true
 qcs-api-client-openapi.workspace = true
 qcs-api-client-grpc.workspace = true
 quil-rs.workspace = true
-reqwest = { version = "0.11.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.11.12", default-features = false, features = [
+  "rustls-tls",
+  "json",
+] }
 rmp-serde = "1.1.1"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 toml = "0.7.3"
-tracing = { version = "0.1", optional = true }
+tracing = { version = "0.1", optional = true, features = ["log"] }
 uuid = { version = "1.2.1", features = ["v4"] }
 tonic = { version = "0.9.2", features = ["tls", "tls-roots"] }
 zmq = { version = "0.10.0" }

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -31,6 +31,7 @@ numpy.workspace = true
 rigetti-pyo3.workspace = true
 paste = "1.0.11"
 pyo3-log = "0.8.2"
+once_cell = "1.18.0"
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -16,7 +16,7 @@ name = "qcs_sdk"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-qcs = { path = "../lib" }
+qcs = { path = "../lib", features = ["tracing"] }
 qcs-api.workspace = true
 qcs-api-client-common.workspace = true
 qcs-api-client-grpc.workspace = true
@@ -30,6 +30,7 @@ thiserror.workspace = true
 numpy.workspace = true
 rigetti-pyo3.workspace = true
 paste = "1.0.11"
+pyo3-log = "0.8.2"
 
 [build-dependencies]
 pyo3-build-config.workspace = true

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -7,3 +7,58 @@ to compile and run Quil programs on Rigetti quantum processors. Internally, it i
 
 While this package can be used directly, [pyQuil](https://pypi.org/project/pyquil/) offers more functionality and a 
 higher-level interface for building and executing Quil programs. This package is still in early development and breaking changes should be expected between minor versions.
+
+## Troubleshooting
+
+### Enabling Debug logging
+
+This package integrates with Python's [logging facility](https://docs.python.org/3/library/logging.html) through a Rust crate called [`pyo3_log`](https://docs.rs/pyo3-log/latest/pyo3_log/). The quickest way to get started is to just enable debug logging:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+Because this is implemented with Rust, there are some important differences in regards to log levels and filtering.
+
+#### The `TRACE` log level
+
+Rust has a `TRACE` log level that doesn't exist in Python. It is less severe than `DEBUG` and is set to a value of 5. While the `DEBUG` level is recommended for troubleshooting, you can choose to target `TRACE` level logs and below like so:
+
+```python
+import logging
+logging.basicConfig(level=5)
+```
+
+#### Runtime Configuration and Caching
+ 
+`pyo3_log` caches loggers and their level filters to improve performance. This means that logger re-configuration done at runtime may cause logs to log or not log as expected in certain situations. If this is a concern, [this section of the pyo3_log documentation](https://docs.rs/pyo3-log/latest/pyo3_log/#performance-filtering-and-caching) goes into more detail.
+
+#### Filtering Logs
+
+Because the logs are emitted from a Rust library, the logger names will correspond to the fully qualified path of the Rust module in the library where the log occured. These fully qualified paths all have their own logger, and have to be configured individually.
+
+For example, say you wanted to disable the following log:
+
+```
+DEBUG:hyper.proto.h1.io:flushed 124 bytes
+```
+
+You could get the logger for `hyper.proto.h1.io` and disable it like so:
+
+```python
+logging.getLogger("hyper.proto.h1.io").disabled = True
+```
+
+This can become cumbersome, since there are a handful of libraries all logging from a handful of modules that you may not be concerned with. A less cumbersome, but more heavy handed approach is to apply a filter to all logging handlers at runtime. For example, if you only cared about logs from a `qcs` library, you could setup a log filter like so:
+
+```python
+class QCSLogFilter(logging.Filter):
+    def filter(self, record) -> bool:
+        return "qcs" in record.name
+
+for handler in logging.root.handlers:
+    handler.addFilter(QCSLogFilter())
+```
+
+This applies to all logs, so you may want to tune the `filter` method to include other logs you care about.

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -36,7 +36,7 @@ logging.basicConfig(level=5)
 
 #### Filtering Logs
 
-Because the logs are emitted from a Rust library, the logger names will correspond to the fully qualified path of the Rust module in the library where the log occured. These fully qualified paths all have their own logger, and have to be configured individually.
+Because the logs are emitted from a Rust library, the logger names will correspond to the fully qualified path of the Rust module in the library where the log occurred. These fully qualified paths all have their own logger, and have to be configured individually.
 
 For example, say you wanted to disable the following log:
 

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -34,6 +34,14 @@ logging.basicConfig(level=5)
  
 `pyo3_log` caches loggers and their level filters to improve performance. This means that logger re-configuration done at runtime may cause unexpected logging behavior in certain situations. If this is a concern, [this section of the pyo3_log documentation](https://docs.rs/pyo3-log/latest/pyo3_log/#performance-filtering-and-caching) goes into more detail.
 
+These caches can be reset using the following:
+
+```python
+qcs_sdk.reset_logging()
+```
+
+This will allow the logging handlers to pick up the most recently-applied configuration from the Python side.
+
 #### Filtering Logs
 
 Because the logs are emitted from a Rust library, the logger names will correspond to the fully qualified path of the Rust module in the library where the log occurred. These fully qualified paths all have their own logger, and have to be configured individually.
@@ -61,4 +69,4 @@ for handler in logging.root.handlers:
     handler.addFilter(QCSLogFilter())
 ```
 
-This applies to all logs, so you may want to tune the `filter` method to include other logs you care about.
+This applies to all logs, so you may want to tune the `filter` method to include other logs you care about. See the caching section above for important information about the application of these filters.

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -32,7 +32,7 @@ logging.basicConfig(level=5)
 
 #### Runtime Configuration and Caching
  
-`pyo3_log` caches loggers and their level filters to improve performance. This means that logger re-configuration done at runtime may cause logs to log or not log as expected in certain situations. If this is a concern, [this section of the pyo3_log documentation](https://docs.rs/pyo3-log/latest/pyo3_log/#performance-filtering-and-caching) goes into more detail.
+`pyo3_log` caches loggers and their level filters to improve performance. This means that logger re-configuration done at runtime may cause unexpected logging behavior in certain situations. If this is a concern, [this section of the pyo3_log documentation](https://docs.rs/pyo3-log/latest/pyo3_log/#performance-filtering-and-caching) goes into more detail.
 
 #### Filtering Logs
 

--- a/crates/python/qcs_sdk/__init__.pyi
+++ b/crates/python/qcs_sdk/__init__.pyi
@@ -355,3 +355,12 @@ class RegisterData:
     def from_f64(inner: Sequence[Sequence[float]]) -> "RegisterData": ...
     @staticmethod
     def from_complex32(inner: Sequence[Sequence[complex]]) -> "RegisterData": ...
+
+
+def reset_logging():
+    """
+    Reset all caches for logging configuration within this library, allowing the most recent Python-side
+    changes to be applied.
+
+    See <https://docs.rs/pyo3-log/latest/pyo3_log/> for more information.
+    """

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -43,5 +43,6 @@ create_init_submodule! {
 
 #[pymodule]
 fn qcs_sdk(py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    pyo3_log::init();
     init_submodule("qcs_sdk", py, m)
 }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use pyo3::prelude::*;
 use rigetti_pyo3::create_init_submodule;
 
@@ -33,6 +35,7 @@ create_init_submodule! {
         ExecutionError,
         RegisterMatrixConversionError
     ],
+    funcs: [ reset_logging ],
     submodules: [
         "client": client::init_submodule,
         "compiler": compiler::init_submodule,
@@ -41,10 +44,27 @@ create_init_submodule! {
     ],
 }
 
+static PY_RESET_LOGGING_HANDLE: once_cell::sync::Lazy<Mutex<Option<pyo3_log::ResetHandle>>> =
+    once_cell::sync::Lazy::new(|| Mutex::new(None));
+
 #[pymodule]
 fn qcs_sdk(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    if let Err(e) = pyo3_log::try_init() {
-        eprintln!("Failed to initialize the qcs_sdk logger: {e}")
+    match pyo3_log::try_init() {
+        Ok(reset_handle) => {
+            if let Ok(mut handle) = PY_RESET_LOGGING_HANDLE.lock() {
+                *handle = Some(reset_handle);
+            }
+        }
+        Err(e) => eprintln!("Failed to initialize the qcs_sdk logger: {e}"),
     }
     init_submodule("qcs_sdk", py, m)
+}
+
+#[pyfunction]
+fn reset_logging() {
+    if let Ok(handle) = PY_RESET_LOGGING_HANDLE.lock() {
+        if let Some(handle) = handle.as_ref() {
+            handle.reset();
+        }
+    }
 }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -43,6 +43,8 @@ create_init_submodule! {
 
 #[pymodule]
 fn qcs_sdk(py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    pyo3_log::init();
+    if let Err(e) = pyo3_log::try_init() {
+        eprintln!("Failed to initialize the qcs_sdk logger: {e}")
+    }
     init_submodule("qcs_sdk", py, m)
 }

--- a/crates/python/tests/logging.py
+++ b/crates/python/tests/logging.py
@@ -1,0 +1,8 @@
+from qcs_sdk import reset_logging
+
+def test_reset_logging():
+    """
+    Assert that resetting logging configuration does not panic.
+    """
+    reset_logging()
+


### PR DESCRIPTION
More detailed logs can be retrieved by setting the log level to `INFO` or lower.

This is implemented via `pyo3_log`, which integrates with Rust's `log`. On the Rust side, we enable the `log` feature of `tracing` so it also emits its logs to `log`. 

![logging3](https://github.com/rigetti/qcs-sdk-rust/assets/4324359/6ad5d9a5-b636-439b-b0f3-e19e5745de95)
