### PR TITLE
fix(py): The `options` parameter on QVM requests is now optional.

### DIFF
--- a/crates/python/qcs_sdk/qvm/api.pyi
+++ b/crates/python/qcs_sdk/qvm/api.pyi
@@ -171,13 +171,17 @@ class MultishotMeasureRequest:
     def rng_seed(self, value: Optional[int]): ...
 
 def run_and_measure(
-    request: MultishotMeasureRequest, client: Optional[QCSClient] = None
+    request: MultishotMeasureRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> List[List[int]]:
     """Executes a program on the QVM, measuring and returning the state of the qubits at the end of each trial."""
     ...
 
 def run_and_measure_async(
-    request: MultishotMeasureRequest, client: Optional[QCSClient] = None
+    request: MultishotMeasureRequest,
+    client: Optional[QCSClient] = None,
+    options: Optional[QVMOptions] = None,
 ) -> List[List[int]]:
     """Executes a program on the QVM, measuring and returning the state of the qubits at the end of each trial."""
     ...

--- a/crates/python/src/qvm/api.rs
+++ b/crates/python/src/qvm/api.rs
@@ -45,7 +45,7 @@ create_init_submodule! {
 }
 
 py_function_sync_async! {
-    #[pyfunction]
+    #[pyfunction(client = "None", options = "None")]
     async fn get_version_info(client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<String> {
         let client = PyQcsClient::get_or_create_client(client).await;
         qcs::qvm::api::get_version_info(&client, options.unwrap_or_default().as_inner())
@@ -135,7 +135,7 @@ py_wrap_data_struct! {
 impl_repr!(PyMultishotResponse);
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
+    #[pyfunction(client = "None", options = "None")]
     async fn run(
         request: PyMultishotRequest,
         client: Option<PyQcsClient>,
@@ -197,7 +197,7 @@ impl PyMultishotMeasureRequest {
 }
 
 py_function_sync_async! {
-    #[pyfunction]
+    #[pyfunction(client = "None", options = "None")]
     async fn run_and_measure(request: PyMultishotMeasureRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<Vec<i64>>> {
         let client = PyQcsClient::get_or_create_client(client).await;
         qcs::qvm::api::run_and_measure(request.as_inner(), &client, options.unwrap_or_default().as_inner())
@@ -229,7 +229,7 @@ impl PyExpectationRequest {
 }
 
 py_function_sync_async! {
-    #[pyfunction]
+    #[pyfunction(client = "None", options = "None")]
     async fn measure_expectation(request: PyExpectationRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<f64>> {
         let client = PyQcsClient::get_or_create_client(client).await;
         qcs::qvm::api::measure_expectation(request.as_inner(), &client, options.unwrap_or_default().as_inner())
@@ -268,7 +268,7 @@ impl PyWavefunctionRequest {
 }
 
 py_function_sync_async! {
-    #[pyfunction(client = "None")]
+    #[pyfunction(client = "None", options = "None")]
     async fn get_wavefunction(request: PyWavefunctionRequest, client: Option<PyQcsClient>, options: Option<PyQvmOptions>) -> PyResult<Vec<u8>> {
         let client = PyQcsClient::get_or_create_client(client).await;
         qcs::qvm::api::get_wavefunction(request.as_inner(), &client, options.unwrap_or_default().as_inner())


### PR DESCRIPTION
In `pyo3`, all trailing `Option<T>` parameters are supposed to optional parameters on the Python side, but I think the way we were wrapping these with sync/async macro might be conflicting with that behavior. Either way, overriding them explicitly fixed the issue.