### PR TITLE
fix: The MissingQubitBenchmark error has been demoted to a warning.

### DIFF
--- a/crates/lib/src/compiler/isa/qubit.rs
+++ b/crates/lib/src/compiler/isa/qubit.rs
@@ -172,8 +172,9 @@ const DEFAULT_DURATION_RX: f64 = 50.0;
 fn rx_gates(node_id: i64, frb_sim_1q: &FrbSim1q) -> Result<Vec<Operator>, Error> {
     let fidelity = match frb_sim_1q.fidelity_for_qubit(node_id) {
         Ok(fidelity) => Ok(fidelity),
-        Err(Error::MissingBenchmarkForQubit(e)) => {
-            tracing::warn!(e);
+        Err(error @ Error::MissingBenchmarkForQubit(_)) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(%error);
             Ok(0.0)
         }
         Err(e) => Err(e),

--- a/crates/lib/src/compiler/isa/qubit.rs
+++ b/crates/lib/src/compiler/isa/qubit.rs
@@ -171,6 +171,8 @@ fn rx_gates(node_id: i64, frb_sim_1q: &FrbSim1q) -> Result<Vec<Operator>, Error>
     let fidelity = frb_sim_1q
         .fidelity_for_qubit(node_id)
         .or_else(|e| match e {
+            // Prevents compilation error when building without the `tracing` feature flag
+            #[allow(unused_variables)]
             error @ Error::MissingBenchmarkForQubit(_) => {
                 #[cfg(feature = "tracing")]
                 tracing::warn!(%error);


### PR DESCRIPTION
A default fidelity of 0.0 is used instead.