### PR TITLE
feat(python): Broaden ExecutionOptions timeout_seconds type to float, add getters for options.

### DIFF
--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -179,6 +179,12 @@ class ExecutionOptions:
     @staticmethod
     def builder() -> ExecutionOptionsBuilder:
         """Get an ``ExecutionOptionsBuilder`` that can be used to build a custom set of ``ExecutionOptions``"""
+    @property
+    def connection_strategy(self) -> ConnectionStrategy:
+        """Get the ``ConnectionStrategy`` to be used to connect to the QPU."""
+    @property
+    def timeout_seconds(self) -> Optional[float]:
+        """The time in seconds to wait before timing out a request, if any."""
 
 @final
 class ExecutionOptionsBuilder:
@@ -200,7 +206,7 @@ class ExecutionOptionsBuilder:
     def timeout_seconds(self):
         raise AttributeError("timeout_seconds is not readable")
     @timeout_seconds.setter
-    def timeout_seconds(self, timeout_seconds: Optional[int]):
+    def timeout_seconds(self, timeout_seconds: Optional[float]):
         """Set the number of seconds to wait before timing out. If set to `None` there is no timeout."""
     def build(self) -> ExecutionOptions:
         """Build the ``ExecutionOptions`` using the options set in this builder."""

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -219,6 +219,18 @@ impl PyExecutionOptions {
     fn builder() -> PyExecutionOptionsBuilder {
         PyExecutionOptionsBuilder::default()
     }
+
+    #[getter]
+    fn connection_strategy(&self) -> PyConnectionStrategy {
+        PyConnectionStrategy(self.as_inner().connection_strategy().clone())
+    }
+
+    #[getter]
+    fn timeout_seconds(&self) -> Option<f64> {
+        self.as_inner()
+            .timeout()
+            .map(|timeout| timeout.as_secs_f64())
+    }
 }
 
 py_wrap_type! {
@@ -251,8 +263,8 @@ impl PyExecutionOptionsBuilder {
     }
 
     #[setter]
-    fn timeout_seconds(&mut self, timeout_seconds: Option<u64>) {
-        let timeout = timeout_seconds.map(Duration::from_secs);
+    fn timeout_seconds(&mut self, timeout_seconds: Option<f64>) {
+        let timeout = timeout_seconds.map(Duration::from_secs_f64);
         *self = Self::from(self.as_inner().clone().timeout(timeout).clone());
     }
 


### PR DESCRIPTION
closes #328 