### PR TITLE
fix(py): The `compiler`, `qpu`, and `qvm` submodules are now packages again

### DIFF
--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -44,7 +44,6 @@ sdist-include = ["README.md"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-quil = "0.1.1"
 
 [tool.poetry.dev-dependencies]
 numpy = "^1.24.1"

--- a/crates/python/qcs_sdk/compiler/__init__.py
+++ b/crates/python/qcs_sdk/compiler/__init__.py
@@ -1,0 +1,4 @@
+from qcs_sdk import compiler
+
+__doc__ = compiler.__doc__
+__all__ = getattr(compiler, "__all__", [])

--- a/crates/python/qcs_sdk/qpu/__init__.py
+++ b/crates/python/qcs_sdk/qpu/__init__.py
@@ -1,0 +1,4 @@
+from qcs_sdk import qpu
+
+__doc__ = qpu.__doc__
+__all__ = getattr(qpu, "__all__", [])

--- a/crates/python/qcs_sdk/qvm/__init__.py
+++ b/crates/python/qcs_sdk/qvm/__init__.py
@@ -1,0 +1,4 @@
+from qcs_sdk import qvm
+
+__doc__ = qvm.__doc__
+__all__ = getattr(qvm, "__all__", [])


### PR DESCRIPTION
When we [added these lines](https://github.com/rigetti/qcs-sdk-rust/blob/main/crates/python/qcs_sdk/__init__.py#L7-L8) I believe we clobbered something that allowed the `compiler` `qpu` and `qvm` modules to be recognized as packages. Fixed by following typical Python convention, and adding an `__init__.py` for each package.