### PR TITLE
build: Use a release profile that reduces binary size

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -123,11 +123,42 @@ jobs:
         with: 
           name: wheels 
           path: dist 
+  sdist:
+    runs-on: ubuntu-latest
+    needs: is-python-release
+    env:
+      CXXFLAGS: "-std=c++11"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        default: true
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - name: Build sdist
+      uses: messense/maturin-action@v1
+      with:
+        command: sdist
+        args: --manifest-path crates/python/Cargo.toml --out dist
+    - name: Upload sdist
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [ macos, linux, windows ]
+    needs: [ macos, linux, windows, sdist ]
     steps:
       - uses: actions/download-artifact@v3
       - name: Publish to PyPi

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -94,7 +94,7 @@ jobs:
     strategy: 
       matrix: 
         python-version: ['3.8', '3.9', '3.10', '3.11'] 
-        target: [x64, x86] 
+        target: [x64] 
     steps: 
       - uses: actions/checkout@v2 
       - uses: actions/setup-python@v2 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ pyo3-asyncio = { version = "0.19", features = ["tokio-runtime"] }
 pyo3-build-config = "0.19.2"
 rigetti-pyo3 = { version = "0.2.0", features = ["complex"] }
 
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ pyo3-asyncio = { version = "0.19", features = ["tokio-runtime"] }
 pyo3-build-config = "0.19.2"
 rigetti-pyo3 = { version = "0.2.0", features = ["complex"] }
 
+# The primary intent of these options is to reduce the binary size for Python wheels
+# since PyPi has limits on how much storage a project can use.
+# The LTO and codegen-units settings should have the added benefit of improving
+# performance. The only benefit of stripping symbols is reducing binary size.
 [profile.release]
 strip = true
 lto = true


### PR DESCRIPTION
closes #366 

Tested some recommendations from the Rust [min-sized-guide](https://github.com/johnthagen/min-sized-rust) to see how they affected binary size.

I think we should use LTO with codegen-units=1. It has a decent impact on the binary size, and we use it in quil-rs already for the performance.

I also don't see any harm in stripping symbols, but I could be convinced otherwise. I'm not sure if they'd ever be useful in practice, as we can just re-build with symbols from a buggy version if we really needed them and I don't think we'd expect users to want to load release wheels into a debugger.

Out of interest, I also tested `-Oz` and aborting on panics. These negatively impact performance and functionality, so they aren't good for our use case, but I was curious to see how much of an impact they had.

# Results

Starting from main, I progressively added one option at a time and measured the resulting wheel, tracking their reduction from the previous step, and overall when compared to the binary generated by main. 

I only built a wheel for my platform on Python 3.11, so mileage may vary for different Python versions and platforms. With that in mind, we can do some potentially irresponsible napkin math. If we take the 35.79% overall reduction from the approach I'm proposing in this PR, and extrapolate it to the 168MB size of all wheels in the last release, we'd reduce it down to 108MB.

| Option                 | Bytes     | Reduction | Overall Reduction
|------------------------|-----------|-----------|------------------
| Current main           | 6,664,209 | -         |
| ^ + strip = true       | 5,471,937 | -17.89%   | -17.89%
| ^ + LTO = true         | 4,664,066 | -17.32%   | -30.01%
| **^ + codegen-units = 1**  | **4,278,771** | **-8.26%**    | **-35.79%**
| ^ + -Oz                | 2,979,780 | -43.59%   | -55.29%
| ^ + panic = "abort"    | 2,514,243 | -62.27%   | -62.27%


For posterity, the wheel I was building:
```
qcs_sdk_python-0.12.3-cp311-cp311-macosx_11_0_arm64.whl
```