### PR TITLE
fix!: use crate-defined translation options

### DIFF
--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use qcs_api_client_common::configuration::LoadError;
-use qcs_api_client_grpc::services::translation::TranslationOptions;
 use quil_rs::quil::ToQuilError;
 
 use crate::client::Qcs;
@@ -16,6 +15,7 @@ use crate::compiler::quilc::{self, CompilerOpts};
 use crate::execution_data::{self, ResultData};
 use crate::qpu::api::{ExecutionOptions, JobId};
 use crate::qpu::rewrite_arithmetic;
+use crate::qpu::translation::TranslationOptions;
 use crate::qpu::ExecutionError;
 use crate::qvm::http::AddressRequest;
 use crate::{qpu, qvm};

--- a/crates/lib/src/qpu/execution.rs
+++ b/crates/lib/src/qpu/execution.rs
@@ -6,7 +6,6 @@ use std::num::NonZeroU16;
 use std::sync::Arc;
 use std::time::Duration;
 
-use qcs_api_client_grpc::services::translation::TranslationOptions;
 use quil_rs::program::ProgramError;
 use quil_rs::quil::ToQuilError;
 
@@ -23,7 +22,7 @@ use super::api::{
     retrieve_results, submit, ConnectionStrategy, ExecutionOptions, ExecutionOptionsBuilder,
 };
 use super::rewrite_arithmetic::RewrittenProgram;
-use super::translation::EncryptedTranslationResult;
+use super::translation::{EncryptedTranslationResult, TranslationOptions};
 use super::QpuResultData;
 use super::{get_isa, GetIsaError};
 use crate::client::{GrpcClientError, Qcs};


### PR DESCRIPTION
Seems that it was intended to require the crate's wrapper for `TranslationOptions`, otherwise the consumer needs to separately install [qcs-api-client-grpc](https://crates.io/crates/qcs-api-client-grpc) to call `submit_to_qpu` https://github.com/rigetti/qcs-sdk-rust/blob/6416c87861583ee0ea0f5ff66c4daa049ac4f14b/crates/lib/src/executable.rs#L540

https://github.com/rigetti/qcs-sdk-rust/blob/c6ec8c4271b6c01c620974722e10d31684b58416/crates/lib/src/qpu/translation.rs#L120

This change will bring things in-line with the python counterpart https://github.com/rigetti/qcs-sdk-rust/blob/c6ec8c4271b6c01c620974722e10d31684b58416/crates/python/src/qpu/translation.rs#L172 https://github.com/rigetti/qcs-sdk-rust/blob/c6ec8c4271b6c01c620974722e10d31684b58416/crates/python/src/qpu/translation.rs#L109