### PR TITLE
feat: make Executable.get_qcs_client public

### DIFF
--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -299,8 +299,9 @@ impl<'executable> Executable<'executable, '_> {
         self
     }
 
-    /// Get a reference to the [`Qcs`] client used by the executable,
-    /// which loads and stores a default client if one has not been set.
+    /// Get a reference to the [`Qcs`] client used by the executable.
+    ///
+    /// If one has not been set, a default client is loaded, set, and returned.
     pub async fn get_qcs_client(&mut self) -> Arc<Qcs> {
         if let Some(client) = &self.qcs_client {
             client.clone()

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -302,7 +302,7 @@ impl<'executable> Executable<'executable, '_> {
     /// Get a reference to the [`Qcs`] client used by the executable.
     ///
     /// If one has not been set, a default client is loaded, set, and returned.
-    pub async fn get_qcs_client(&mut self) -> Arc<Qcs> {
+    pub async fn qcs_client(&mut self) -> Arc<Qcs> {
         if let Some(client) = &self.qcs_client {
             client.clone()
         } else {
@@ -414,7 +414,7 @@ impl<'execution> Executable<'_, 'execution> {
             self.quil.clone(),
             self.shots,
             id,
-            self.get_qcs_client().await,
+            self.qcs_client().await,
             self.quilc_client.clone(),
             self.compiler_options,
         )
@@ -854,7 +854,7 @@ mod describe_qpu_for_id {
                 "".into(),
                 shots,
                 "Aspen-M-3".into(),
-                exe.get_qcs_client().await,
+                exe.qcs_client().await,
                 exe.quilc_client.clone(),
                 CompilerOpts::default(),
             )

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -299,14 +299,15 @@ impl<'executable> Executable<'executable, '_> {
         self
     }
 
-    /// Load `self.client` if not yet loaded, then return a reference to it.
-    async fn get_qcs_client(&mut self) -> Result<Arc<Qcs>, Error> {
+    /// Get a reference to the [`Qcs`] client used by the executable,
+    /// which loads and stores a default client if one has not been set.
+    pub async fn get_qcs_client(&mut self) -> Arc<Qcs> {
         if let Some(client) = &self.qcs_client {
-            Ok(client.clone())
+            client.clone()
         } else {
             let client = Arc::new(Qcs::load().await);
             self.qcs_client = Some(client.clone());
-            Ok(client)
+            client
         }
     }
 }
@@ -412,7 +413,7 @@ impl<'execution> Executable<'_, 'execution> {
             self.quil.clone(),
             self.shots,
             id,
-            self.get_qcs_client().await?,
+            self.get_qcs_client().await,
             self.quilc_client.clone(),
             self.compiler_options,
         )
@@ -852,7 +853,7 @@ mod describe_qpu_for_id {
                 "".into(),
                 shots,
                 "Aspen-M-3".into(),
-                exe.get_qcs_client().await.expect("should have client"),
+                exe.get_qcs_client().await,
                 exe.quilc_client.clone(),
                 CompilerOpts::default(),
             )


### PR DESCRIPTION
Up for debate, but in cases where you need to provide some execution configuration, it would help to use a single source of truth for the qcs client


For example, to use https://github.com/rigetti/qcs-sdk-rust/blob/a4c832ca7360d546a0bd0c71230353f6a4b28eaa/crates/lib/src/executable.rs#L367 

Here's what you have to do:

```rust
// ... in some other function ...

let exe = qcs::executable::Executable::from_quil("...");

// ... later on ...

// > before this change: who knows if `exe` is configured with
// the same client or if we're doing a redundant load
let qcs_client = qcs::client::Qcs::load().await;

// > after this change: same client, only one load
let qcs_client = exe.get_qcs_client().await;

let qvm_client = qcs::qvm::http::HttpClient::from(&qcs_client);
exe.execute_on_qvm(&qvm_client)
```