### PR TITLE
feat: Improve error message when a quilc connection fails.

### DIFF
--- a/crates/lib/src/compiler/quilc.rs
+++ b/crates/lib/src/compiler/quilc.rs
@@ -206,7 +206,7 @@ pub enum Error {
     #[error("Problem converting ISA to quilc format. This is a bug in this library or in QCS.")]
     Isa(#[from] isa::Error),
     /// An error when trying to connect to quilc.
-    #[error("Problem connecting to quilc at {0}")]
+    #[error("Problem connecting to quilc at {0}: {1}")]
     QuilcConnection(String, #[source] rpcq::Error),
     /// An error when trying to compile using quilc.
     #[error("Problem compiling quil program: {0}")]


### PR DESCRIPTION
When the `QuilcConnection` error occurs, the resulting error message is vague and doesn't give a hint towards what the issue might be if you know your `quilc` server is running at the right port. For example, this is how the error manifests in `quil-py`:

```
quilc.QuilcError: Problem connecting to quilc at tcp://127.0.0.1:5555
```

This PR appends the RPCQ error to the message and hopefully adds a bit more context and gives a better hint at what might be going wrong.