### PR TITLE
test: libquil quilc client as executable quilc client

### DIFF
--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -902,4 +902,10 @@ mod describe_qpu_for_id {
         assert!(matches!(result, Err(_)));
         assert!(matches!(exe.qpu, None));
     }
+
+    #[cfg(feature = "libquil")]
+    fn test_uses_libquil_quilc_client() {
+        let _ = Executable::from_quil("")
+            .with_quilc_client(Some(crate::compiler::libquil::Client));
+    }
 }


### PR DESCRIPTION
Maybe I am doing this wrong, but I get the following error:

```rs
error[E0271]: type mismatch resolving `<Client as Client>::Error == Error`
   --> crates/lib/src/executable.rs:909:32
    |
909 |             .with_quilc_client(Some(crate::compiler::libquil::Client));
    |              ----------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Client as Client>::Error == Error`
    |              |
    |              required by a bound introduced by this call
    |
note: expected this to be `compiler::quilc::Error`
   --> crates/lib/src/compiler/libquil.rs:55:18
    |
55  |     type Error = Error;
    |                  ^^^^^
    = note: `compiler::libquil::Error` and `compiler::quilc::Error` have similar names, but are actually distinct types
note: `compiler::libquil::Error` is defined in module `crate::compiler::libquil` of the current crate
   --> crates/lib/src/compiler/libquil.rs:13:1
    |
13  | pub enum Error {
    | ^^^^^^^^^^^^^^
note: `compiler::quilc::Error` is defined in module `crate::compiler::quilc` of the current crate
   --> crates/lib/src/compiler/quilc.rs:206:1
    |
206 | pub enum Error {
    | ^^^^^^^^^^^^^^
note: required by a bound in `Executable::<'_, '_>::with_quilc_client`
   --> crates/lib/src/executable.rs:332:47
    |
332 |     pub fn with_quilc_client<C: quilc::Client<Error = quilc::Error> + Send + Sync + 'static>(
    |                                               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `Executable::<'_, '_>::with_quilc_client`


```