### PR TITLE
chore: add tests to reproduce libquil-sys compilation failure

### DIFF
--- a/crates/lib/src/compiler/libquil.rs
+++ b/crates/lib/src/compiler/libquil.rs
@@ -344,4 +344,21 @@ MEASURE 1 ro[1]
             }
         );
     }
+
+    #[tokio::test]
+    async fn test_parametric_compilation() {
+        let client = quilc_client();
+        let isa = TargetDevice::try_from(aspen_9_isa())
+            .expect("aspen-9 compiler isa should become TargetDevice");
+        const PARAMETRIC_PROGRAM: &str = r#"
+PRAGMA INITIAL_REWIRING "PARTIAL"
+DECLARE ro BIT
+DECLARE theta REAL
+RX(theta) 0
+MEASURE 0 ro
+"#;
+        client
+            .compile_program(PARAMETRIC_PROGRAM, isa, CompilerOpts::new())
+            .expect("program should compile");
+    }
 }

--- a/crates/lib/src/compiler/quilc.rs
+++ b/crates/lib/src/compiler/quilc.rs
@@ -490,4 +490,21 @@ MEASURE 1 ro[1]
             }
         );
     }
+
+    #[tokio::test]
+    async fn test_parametric_compilation() {
+        let client = rpcq_client().await;
+        let isa = TargetDevice::try_from(aspen_9_isa())
+            .expect("aspen-9 compiler isa should become TargetDevice");
+        const PARAMETRIC_PROGRAM: &str = r#"
+PRAGMA INITIAL_REWIRING "PARTIAL"
+DECLARE ro BIT
+DECLARE theta REAL
+RX(theta) 0
+MEASURE 0 ro
+"#;
+        client
+            .compile_program(PARAMETRIC_PROGRAM, isa, CompilerOpts::new())
+            .expect("program should compile");
+    }
 }


### PR DESCRIPTION
I expect the error in `crates/lib/src/compiler/libquil.rs` to fail, or at least it does for me locally.