### PR TITLE
feat: provide ExecutionOptions configurability as ApiExecutionOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad78be261af4de4d54bfb03019ae5c564c5e966d4ca64f883cef25ed07d218d"
+checksum = "cc3356caa74bb697c4271c950a3040e8dbb9448a9bd0124411b9b43155b8e192"
 dependencies = [
  "async-trait",
  "futures",
@@ -2135,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-grpc"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e298dc6ce58bca734eed37f7934cc82e3d34463ac3e067bd4ad57fa903b55b"
+checksum = "37bd1842ca3485e8c0abf36be4cbcee1ea12e97da15ac731ce9dae20f7f58f41"
 dependencies = [
  "http",
  "http-body",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-openapi"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e970a25b7a98e040ca03badddae6d23b5a5f58189bd0e112770b7a9126b05296"
+checksum = "c605c4bdf887f487dbe7c0055f303728a992a6d508eedc55d7efa41b36adba07"
 dependencies = [
  "anyhow",
  "qcs-api-client-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ resolver = "2"
 
 [workspace.dependencies]
 qcs-api = "0.2.1"
-qcs-api-client-common = "0.7.7"
-qcs-api-client-grpc = "0.7.7"
-qcs-api-client-openapi = "0.8.7"
+qcs-api-client-common = "0.7.9"
+qcs-api-client-grpc = "0.7.9"
+qcs-api-client-openapi = "0.8.9"
 serde_json = "1.0.86"
 thiserror = "1.0.37"
 tokio = "1.34.0"

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -197,7 +197,7 @@ pub type QpuConnectionOptionsBuilder = ExecutionOptionsBuilder;
 ///
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ExecutionOptionsBuilder`]
 /// to build a custom set of options.
-#[derive(Builder, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Builder, Clone, Debug, Default, PartialEq)]
 pub struct ExecutionOptions {
     #[doc = "The [`ConnectionStrategy`] to use to establish a connection to the QPU."]
     #[builder(default)]
@@ -207,10 +207,13 @@ pub struct ExecutionOptions {
     timeout: Option<Duration>,
     #[doc = "Options avaialable when executing a job on a QPU, particular to the execution service's API."]
     #[builder(default = "None")]
-    api_options: Option<ApiExecutionOptions>,
+    api_options: Option<InnerApiExecutionOptions>,
 }
 
+impl Eq for ExecutionOptions {}
+
 /// Options avaialable when executing a job on a QPU, particular to the execution service's API.
+/// This is a conventent alias for [`InnerApiExecutionOptions`] which provides a builder.
 ///
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ApiExecutionOptionsBuilder`]
 /// to build a custom set of options.
@@ -240,6 +243,12 @@ impl ApiExecutionOptions {
 impl From<ApiExecutionOptions> for InnerApiExecutionOptions {
     fn from(options: ApiExecutionOptions) -> Self {
         options.inner
+    }
+}
+
+impl From<InnerApiExecutionOptions> for ApiExecutionOptions {
+    fn from(inner: InnerApiExecutionOptions) -> Self {
+        Self { inner }
     }
 }
 
@@ -274,7 +283,7 @@ impl ExecutionOptions {
 
     /// Get the [`ApiExecutionOptions`].
     #[must_use]
-    pub fn api_options(&self) -> Option<&ApiExecutionOptions> {
+    pub fn api_options(&self) -> Option<&InnerApiExecutionOptions> {
         self.api_options.as_ref()
     }
 }

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -214,21 +214,11 @@ pub struct ExecutionOptions {
 ///
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ApiExecutionOptionsBuilder`]
 /// to build a custom set of options.
-#[derive(Builder, Clone, Debug, Default)]
+#[derive(Builder, Clone, Debug, Default, PartialEq)]
 #[allow(clippy::module_name_repetitions)]
 pub struct ApiExecutionOptions {
     /// the inner proto representation
     inner: InnerApiExecutionOptions,
-}
-
-impl PartialEq for ApiExecutionOptions {
-    /// implement Eq
-    fn eq(&self, other: &Self) -> bool {
-        let InnerApiExecutionOptions {
-            bypass_settings_protection,
-        } = self.inner;
-        bypass_settings_protection == other.inner.bypass_settings_protection
-    }
 }
 
 impl Eq for ApiExecutionOptions {}

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -104,9 +104,7 @@ pub async fn submit(
         execution_configurations: vec![params_into_job_execution_configuration(patch_values)],
         job: Some(execute_controller_job_request::Job::Encrypted(program)),
         target: execution_options.get_job_target(quantum_processor_id),
-        options: execution_options
-            .api_options()
-            .map(|options| options.clone().into()),
+        options: execution_options.api_options().cloned(),
     };
 
     let mut controller_client = execution_options

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -106,7 +106,7 @@ pub async fn submit(
         target: execution_options.get_job_target(quantum_processor_id),
         options: execution_options
             .api_options()
-            .map(|options| options.to_owned().into()),
+            .map(|options| options.clone().into()),
     };
 
     let mut controller_client = execution_options
@@ -215,6 +215,7 @@ pub struct ExecutionOptions {
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ApiExecutionOptionsBuilder`]
 /// to build a custom set of options.
 #[derive(Builder, Clone, Debug, Default)]
+#[allow(clippy::module_name_repetitions)]
 pub struct ApiExecutionOptions {
     /// the inner proto representation
     inner: InnerApiExecutionOptions,

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -205,7 +205,7 @@ pub struct ExecutionOptions {
     #[doc = "The timeout to use for the request, defaults to 30 seconds. If set to `None`, then there is no timeout."]
     #[builder(default = "Some(Duration::from_secs(30))")]
     timeout: Option<Duration>,
-    #[doc = "If `true` and the user is authorized, jobs will bypass change protection against managed settings."]
+    #[doc = "Options avaialable when executing a job on a QPU, particular to the execution service's API."]
     #[builder(default = "None")]
     api_options: Option<ApiExecutionOptions>,
 }
@@ -224,7 +224,10 @@ pub struct ApiExecutionOptions {
 impl PartialEq for ApiExecutionOptions {
     /// implement Eq
     fn eq(&self, other: &Self) -> bool {
-        self.inner.bypass_settings_protection == other.inner.bypass_settings_protection
+        let InnerApiExecutionOptions {
+            bypass_settings_protection,
+        } = self.inner;
+        bypass_settings_protection == other.inner.bypass_settings_protection
     }
 }
 

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -193,6 +193,9 @@ class ExecutionOptions:
     @property
     def timeout_seconds(self) -> Optional[float]:
         """The time in seconds to wait before timing out a request, if any."""
+    @property
+    def api_options(self) -> bool:
+        """Execution options particular to the API call at the point of execution."""
 
 @final
 class ExecutionOptionsBuilder:
@@ -216,8 +219,43 @@ class ExecutionOptionsBuilder:
     @timeout_seconds.setter
     def timeout_seconds(self, timeout_seconds: Optional[float]):
         """Set the number of seconds to wait before timing out. If set to `None` there is no timeout."""
+    @property
+    def api_options(self) -> bool:
+        raise AttributeError("api_options is not readable")
+    @api_options.setter
+    def api_options(self, api_options: ApiExecutionOptions):
+        """Execution options particular to the API call at the point of execution."""
     def build(self) -> ExecutionOptions:
         """Build the ``ExecutionOptions`` using the options set in this builder."""
+
+@final
+class ApiExecutionOptions:
+    @staticmethod
+    def default() -> ApiExecutionOptions:
+        """Return ApiExecutionOptions with a reasonable set of defaults."""
+        ...
+    @staticmethod
+    def builder() -> ApiExecutionOptionsBuilder:
+        """Get an ``ApiExecutionOptionsBuilder`` that can be used to build a custom set of ``ApiExecutionOptions``"""
+    @property
+    def bypass_settings_protection(self) -> bool:
+        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
+
+@final
+class ApiExecutionOptionsBuilder:
+    def __new__(cls) -> ApiExecutionOptionsBuilder: ...
+    @staticmethod
+    def default() -> ApiExecutionOptionsBuilder:
+        """Return a builder with the default values for ``ApiExecutionOptions``"""
+        ...
+    @property
+    def bypass_settings_protection(self) -> bool:
+        raise AttributeError("bypass_settings_protection is not readable")
+    @bypass_settings_protection.setter
+    def bypass_settings_protection(self, bypass_settings_protection: bool):
+        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
+    def build(self) -> ExecutionOptions:
+        """Build the ``ApiExecutionOptions`` using the options set in this builder."""
 
 @final
 class ConnectionStrategy:

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -223,30 +223,30 @@ class ExecutionOptionsBuilder:
     def api_options(self) -> bool:
         raise AttributeError("api_options is not readable")
     @api_options.setter
-    def api_options(self, api_options: ApiExecutionOptions):
+    def api_options(self, api_options: APIExecutionOptions):
         """Execution options particular to the API call at the point of execution."""
     def build(self) -> ExecutionOptions:
         """Build the ``ExecutionOptions`` using the options set in this builder."""
 
 @final
-class ApiExecutionOptions:
+class APIExecutionOptions:
     @staticmethod
-    def default() -> ApiExecutionOptions:
-        """Return ApiExecutionOptions with a reasonable set of defaults."""
+    def default() -> APIExecutionOptions:
+        """Return APIExecutionOptions with a reasonable set of defaults."""
         ...
     @staticmethod
-    def builder() -> ApiExecutionOptionsBuilder:
-        """Get an ``ApiExecutionOptionsBuilder`` that can be used to build a custom set of ``ApiExecutionOptions``"""
+    def builder() -> APIExecutionOptionsBuilder:
+        """Get an ``APIExecutionOptionsBuilder`` that can be used to build a custom set of ``APIExecutionOptions``"""
     @property
     def bypass_settings_protection(self) -> bool:
         """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
 
 @final
-class ApiExecutionOptionsBuilder:
-    def __new__(cls) -> ApiExecutionOptionsBuilder: ...
+class APIExecutionOptionsBuilder:
+    def __new__(cls) -> APIExecutionOptionsBuilder: ...
     @staticmethod
-    def default() -> ApiExecutionOptionsBuilder:
-        """Return a builder with the default values for ``ApiExecutionOptions``"""
+    def default() -> APIExecutionOptionsBuilder:
+        """Return a builder with the default values for ``APIExecutionOptions``"""
         ...
     @property
     def bypass_settings_protection(self) -> bool:
@@ -254,8 +254,8 @@ class ApiExecutionOptionsBuilder:
     @bypass_settings_protection.setter
     def bypass_settings_protection(self, bypass_settings_protection: bool):
         """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
-    def build(self) -> ApiExecutionOptions:
-        """Build the ``ApiExecutionOptions`` using the options set in this builder."""
+    def build(self) -> APIExecutionOptions:
+        """Build the ``APIExecutionOptions`` using the options set in this builder."""
 
 @final
 class ConnectionStrategy:

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -254,7 +254,7 @@ class ApiExecutionOptionsBuilder:
     @bypass_settings_protection.setter
     def bypass_settings_protection(self, bypass_settings_protection: bool):
         """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
-    def build(self) -> ExecutionOptions:
+    def build(self) -> ApiExecutionOptions:
         """Build the ``ApiExecutionOptions`` using the options set in this builder."""
 
 @final

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -36,7 +36,9 @@ create_init_submodule! {
         ExecutionResults,
         PyConnectionStrategy,
         PyExecutionOptions,
-        PyExecutionOptionsBuilder
+        PyExecutionOptionsBuilder,
+        PyApiExecutionOptions,
+        PyApiExecutionOptionsBuilder
     ],
     errors: [
         SubmissionError,
@@ -349,6 +351,24 @@ impl PyExecutionOptions {
     }
 }
 
+#[pymethods]
+impl PyApiExecutionOptions{
+    #[staticmethod]
+    fn default() -> Self {
+        Self::from(ApiExecutionOptions::default())
+    }
+
+    #[staticmethod]
+    fn builder() -> PyApiExecutionOptionsBuilder {
+        PyApiExecutionOptionsBuilder::default()
+    }
+
+    #[getter]
+    fn bypass_settings_protection(&self) -> bool {
+        self.as_inner().bypass_settings_protection()
+    }
+}
+
 py_wrap_type! {
     PyExecutionOptionsBuilder(ExecutionOptionsBuilder) as "ExecutionOptionsBuilder"
 }
@@ -430,6 +450,14 @@ impl PyApiExecutionOptionsBuilder {
                 .bypass_settings_protection(bypass_settings_protection)
                 .clone(),
         );
+    }
+
+    fn build(&self) -> PyResult<PyApiExecutionOptions> {
+        Ok(PyApiExecutionOptions::from(
+            self.as_inner()
+                .build()
+                .map_err(|err| PyValueError::new_err(err.to_string()))?,
+        ))
     }
 }
 

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -352,7 +352,7 @@ impl PyExecutionOptions {
 }
 
 #[pymethods]
-impl PyApiExecutionOptions{
+impl PyApiExecutionOptions {
     #[staticmethod]
     fn default() -> Self {
         Self::from(ApiExecutionOptions::default())

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -307,7 +307,7 @@ impl_as_mut_for_wrapper!(PyExecutionOptions);
 
 py_wrap_type! {
     #[derive(Debug, Default)]
-    PyApiExecutionOptions(ApiExecutionOptions) as "ApiExecutionOptions"
+    PyApiExecutionOptions(ApiExecutionOptions) as "APIExecutionOptions"
 }
 impl_repr!(PyApiExecutionOptions);
 impl_as_mut_for_wrapper!(PyApiExecutionOptions);
@@ -424,7 +424,7 @@ impl PyExecutionOptionsBuilder {
 }
 
 py_wrap_type! {
-    PyApiExecutionOptionsBuilder(ApiExecutionOptionsBuilder) as "ApiExecutionOptionsBuilder"
+    PyApiExecutionOptionsBuilder(ApiExecutionOptionsBuilder) as "APIExecutionOptionsBuilder"
 }
 
 #[pymethods]

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -403,7 +403,7 @@ impl PyExecutionOptionsBuilder {
         *self = Self::from(
             self.as_inner()
                 .clone()
-                .api_options(api_options.map(|x| x.into_inner()))
+                .api_options(api_options.map(|x| x.into_inner().into()))
                 .clone(),
         );
     }


### PR DESCRIPTION
Closes #414 

Allows the new proto `ExecutionOptions` to be configured, embedded within the existing `ExecutionOptions`.