### PR TITLE
#414: Use a combined `ExecutionOptions` struct

### DIFF
--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -194,8 +194,8 @@ class ExecutionOptions:
     def timeout_seconds(self) -> Optional[float]:
         """The time in seconds to wait before timing out a request, if any."""
     @property
-    def api_options(self) -> bool:
-        """Execution options particular to the API call at the point of execution."""
+    def bypass_settings_protection(self) -> bool:
+        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
 
 @final
 class ExecutionOptionsBuilder:
@@ -220,42 +220,13 @@ class ExecutionOptionsBuilder:
     def timeout_seconds(self, timeout_seconds: Optional[float]):
         """Set the number of seconds to wait before timing out. If set to `None` there is no timeout."""
     @property
-    def api_options(self) -> bool:
-        raise AttributeError("api_options is not readable")
-    @api_options.setter
-    def api_options(self, api_options: APIExecutionOptions):
-        """Execution options particular to the API call at the point of execution."""
-    def build(self) -> ExecutionOptions:
-        """Build the ``ExecutionOptions`` using the options set in this builder."""
-
-@final
-class APIExecutionOptions:
-    @staticmethod
-    def default() -> APIExecutionOptions:
-        """Return APIExecutionOptions with a reasonable set of defaults."""
-        ...
-    @staticmethod
-    def builder() -> APIExecutionOptionsBuilder:
-        """Get an ``APIExecutionOptionsBuilder`` that can be used to build a custom set of ``APIExecutionOptions``"""
-    @property
-    def bypass_settings_protection(self) -> bool:
-        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
-
-@final
-class APIExecutionOptionsBuilder:
-    def __new__(cls) -> APIExecutionOptionsBuilder: ...
-    @staticmethod
-    def default() -> APIExecutionOptionsBuilder:
-        """Return a builder with the default values for ``APIExecutionOptions``"""
-        ...
-    @property
     def bypass_settings_protection(self) -> bool:
         raise AttributeError("bypass_settings_protection is not readable")
     @bypass_settings_protection.setter
     def bypass_settings_protection(self, bypass_settings_protection: bool):
         """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
-    def build(self) -> APIExecutionOptions:
-        """Build the ``APIExecutionOptions`` using the options set in this builder."""
+    def build(self) -> ExecutionOptions:
+        """Build the ``ExecutionOptions`` using the options set in this builder."""
 
 @final
 class ConnectionStrategy:

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -195,7 +195,7 @@ class ExecutionOptions:
         """The time in seconds to wait before timing out a request, if any."""
     @property
     def bypass_settings_protection(self) -> bool:
-        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
+        """If jobs contain settings that would cause managed settings to change values, that job will be rejected unless this field is set to true and the submitter has the appropriate authorization."""
 
 @final
 class ExecutionOptionsBuilder:
@@ -224,7 +224,7 @@ class ExecutionOptionsBuilder:
         raise AttributeError("bypass_settings_protection is not readable")
     @bypass_settings_protection.setter
     def bypass_settings_protection(self, bypass_settings_protection: bool):
-        """Whether or not to force managed settings to change, if applicable. Subject to additional authorization requirements."""
+        """If jobs contain settings that would cause managed settings to change values, that job will be rejected unless this field is set to true and the submitter has the appropriate authorization.."""
     def build(self) -> ExecutionOptions:
         """Build the ``ExecutionOptions`` using the options set in this builder."""
 

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -11,10 +11,7 @@ use pyo3::{
     types::{PyComplex, PyInt},
     IntoPy, Py, PyObject, PyResult, Python, ToPyObject,
 };
-use qcs::qpu::api::{
-    ApiExecutionOptions, ApiExecutionOptionsBuilder, ConnectionStrategy, ExecutionOptions,
-    ExecutionOptionsBuilder,
-};
+use qcs::qpu::api::{ConnectionStrategy, ExecutionOptions, ExecutionOptionsBuilder};
 use qcs_api_client_grpc::models::controller::{
     data_value, readout_values, ControllerJobExecutionResult,
 };
@@ -36,9 +33,7 @@ create_init_submodule! {
         ExecutionResults,
         PyConnectionStrategy,
         PyExecutionOptions,
-        PyExecutionOptionsBuilder,
-        PyApiExecutionOptions,
-        PyApiExecutionOptionsBuilder
+        PyExecutionOptionsBuilder
     ],
     errors: [
         SubmissionError,
@@ -305,13 +300,6 @@ py_wrap_type! {
 impl_repr!(PyExecutionOptions);
 impl_as_mut_for_wrapper!(PyExecutionOptions);
 
-py_wrap_type! {
-    #[derive(Debug, Default)]
-    PyApiExecutionOptions(ApiExecutionOptions) as "APIExecutionOptions"
-}
-impl_repr!(PyApiExecutionOptions);
-impl_as_mut_for_wrapper!(PyApiExecutionOptions);
-
 #[pymethods]
 impl PyExecutionOptions {
     #[staticmethod]
@@ -337,10 +325,8 @@ impl PyExecutionOptions {
     }
 
     #[getter]
-    fn api_options(&self) -> Option<PyApiExecutionOptions> {
-        self.as_inner()
-            .api_options()
-            .map(|x| PyApiExecutionOptions(x.clone().into()))
+    fn bypass_settings_protection(&self) -> bool {
+        self.as_inner().bypass_settings_protection()
     }
 
     fn __richcmp__(&self, py: Python<'_>, other: &Self, op: CompareOp) -> PyObject {
@@ -348,24 +334,6 @@ impl PyExecutionOptions {
             CompareOp::Eq => (self.as_inner() == other.as_inner()).into_py(py),
             _ => py.NotImplemented(),
         }
-    }
-}
-
-#[pymethods]
-impl PyApiExecutionOptions{
-    #[staticmethod]
-    fn default() -> Self {
-        Self::from(ApiExecutionOptions::default())
-    }
-
-    #[staticmethod]
-    fn builder() -> PyApiExecutionOptionsBuilder {
-        PyApiExecutionOptionsBuilder::default()
-    }
-
-    #[getter]
-    fn bypass_settings_protection(&self) -> bool {
-        self.as_inner().bypass_settings_protection()
     }
 }
 
@@ -399,11 +367,11 @@ impl PyExecutionOptionsBuilder {
     }
 
     #[setter]
-    fn api_options(&mut self, api_options: Option<PyApiExecutionOptions>) {
+    fn bypass_settings_protection(&mut self, bypass_settings_protection: bool) {
         *self = Self::from(
             self.as_inner()
                 .clone()
-                .api_options(api_options.map(|x| x.into_inner()))
+                .bypass_settings_protection(bypass_settings_protection)
                 .clone(),
         );
     }
@@ -416,44 +384,6 @@ impl PyExecutionOptionsBuilder {
 
     fn build(&self) -> PyResult<PyExecutionOptions> {
         Ok(PyExecutionOptions::from(
-            self.as_inner()
-                .build()
-                .map_err(|err| PyValueError::new_err(err.to_string()))?,
-        ))
-    }
-}
-
-py_wrap_type! {
-    PyApiExecutionOptionsBuilder(ApiExecutionOptionsBuilder) as "APIExecutionOptionsBuilder"
-}
-
-#[pymethods]
-impl PyApiExecutionOptionsBuilder {
-    #[new]
-    fn new() -> Self {
-        Self::default()
-    }
-
-    #[staticmethod]
-    fn default() -> Self {
-        Self::from(ApiExecutionOptionsBuilder::default())
-    }
-
-    #[setter]
-    fn bypass_settings_protection(&mut self, bypass_settings_protection: bool) {
-        // `derive_builder::Builder` doesn't implement AsMut, meaning we can't use `PyWrapperMut`,
-        // which forces us into this awkward clone.
-
-        *self = Self::from(
-            self.as_inner()
-                .clone()
-                .bypass_settings_protection(bypass_settings_protection)
-                .clone(),
-        );
-    }
-
-    fn build(&self) -> PyResult<PyApiExecutionOptions> {
-        Ok(PyApiExecutionOptions::from(
             self.as_inner()
                 .build()
                 .map_err(|err| PyValueError::new_err(err.to_string()))?,


### PR DESCRIPTION
This is an alternate implementation of #415 based on suggestion from https://github.com/rigetti/qcs-sdk-rust/pull/415#discussion_r1443517978