### PR TITLE
ci: Run checks on push to main, or on pull request

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,9 @@
 name: Run Checks
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   checks:


### PR DESCRIPTION
I believe this behavior is a bit more efficient and reflects what we want better. I believe it fixes an issue where PRs from forked repos won't run the checks.