### PR TITLE
ci: Use trusted publishing for PyPI

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -177,12 +177,11 @@ jobs:
     # can be published.
     needs: [ macos, linux, windows, sdist ]
     if: always() && needs.sdist.result == 'success'
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
       - name: Publish to PyPI
-        env:
-          MATURIN_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          MATURIN_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         uses: messense/maturin-action@v1
         with:
           command: upload 


### PR DESCRIPTION
closes #421 

This repo has been setup as a trusted publisher for qcs-sdk-python in PyPI. I've modified the workflow per the [maturin documentation](https://www.maturin.rs/distribution.html?highlight=trusted%20p#using-pypis-trusted-publishing).