### PR TITLE
fix: bump quil-rs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,8 +2213,8 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quil-rs"
-version = "0.22.3"
-source = "git+https://github.com/rigetti/quil-rs?tag=quil-py/v0.6.3#a58a14efd45c64d0f3de477e6ab84d927f6fd0c4"
+version = "0.22.6"
+source = "git+https://github.com/rigetti/quil-rs?tag=quil-py/v0.6.6#b406c3e98a974e391d16236a75b8e6cbea102f2f"
 dependencies = [
  "approx",
  "indexmap 1.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = "1.34.0"
 # be a `quil-py` tag and should match the version used in `crates/python/pyproject.toml`
 # The version must also be specified in order to publish to crates.io. Cargo enforces
 # that the specified version is the same as the version in the git repository.
-quil-rs = { version = "0.22.3", git = "https://github.com/rigetti/quil-rs", tag = "quil-py/v0.6.3" }
+quil-rs = { version = "0.22.6", git = "https://github.com/rigetti/quil-rs", tag = "quil-py/v0.6.6" }
 
 # ndarray is used by the `qcs` crate, but it is also used in the `python` crate via a
 # re-export through the numpy crate. They should be updated as a pair to keep both

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,8 @@ ignore = [
     "RUSTSEC-2023-0052",  # Introduced by transitive dependency `webpki`.
                           # `hyper-proxy`, then `qcs-api-client-rust` need to update in order to remove
                           # `webpki`.
+    "RUSTSEC-2023-0055",  # there isn't a newer version of lexical with a fix
+    "RUSTSEC-2024-0006",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
quil-rs [has a fix](https://github.com/rigetti/quil-rs/pull/338) for `DEFCIRCUIT` serialization