### PR TITLE
feat: Support running a program with multiple sets of patch values in a single request.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b591a8d1498c533f714c6b6f420ffbab9577e6fc92b0d07d05b9e6e3689e90"
+checksum = "a168b5d1b4f6570e42c410f2476762db1e9bf0cc0816c30680b5869ddfebab8e"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2190,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-grpc"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52716630ac986eabf83be964118fa5cc109f50e3404e37b5a6a7a8e801ea96a8"
+checksum = "a1713c430354ce95c6a77f08a4e3ce0599a69b1d65be7e7cc97f5c6fcc94e8f3"
 dependencies = [
  "backoff",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 qcs-api = "0.2.1"
 qcs-api-client-common = "0.7.10"
-qcs-api-client-grpc = "0.7.12"
+qcs-api-client-grpc = "0.7.13"
 qcs-api-client-openapi = "0.8.11"
 serde_json = "1.0.86"
 thiserror = "1.0.37"

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -82,7 +82,8 @@ impl From<String> for JobId {
 ///      is required unless using [`ConnectionStrategy::EndpointId`] in `execution_options`
 ///      to target a specific endpoint ID.
 /// * `program` - The compiled program as an [`EncryptedControllerJob`]
-/// * `patch_values` - The parameters to use for the execution.
+/// * `patch_values` - The parameters to use for the execution. See [`submit_with_parameter_batch`]
+///      if you need to execute with multiple sets of parameters.
 /// * `client` - The [`Qcs`] client to use.
 /// * `execution_options` - The [`ExecutionOptions`] to use. If the connection strategy used
 ///       is [`ConnectionStrategy::EndpointId`] then direct access to that endpoint
@@ -94,6 +95,53 @@ pub async fn submit(
     client: &Qcs,
     execution_options: &ExecutionOptions,
 ) -> Result<JobId, QpuApiError> {
+    submit_with_parameter_batch(
+        quantum_processor_id,
+        program,
+        std::iter::once(patch_values),
+        client,
+        execution_options,
+    )
+    .await?
+    .pop()
+    .ok_or_else(|| GrpcClientError::ResponseEmpty("Job Execution ID".into()))
+    .map_err(QpuApiError::from)
+}
+
+/// Execute a compiled program on a QPU with multiple sets of `patch_values`.
+///
+/// This action is *atomic* in that all jobs will be queued, or none of them will. On success, this
+/// function will return a vector of [`JobId`] where the length and order correspond to the
+/// `patch_values` given. However, note that execution in the order of given patch values is not
+/// guaranteed. If there is a failure to queue any of the jobs, then none will be queued.
+///
+/// # Arguments
+/// * `quantum_processor_id` - The quantum processor to execute the job on. This parameter
+///      is required unless using [`ConnectionStrategy::EndpointId`] in `execution_options`
+///      to target a specific endpoint ID.
+/// * `program` - The compiled program as an [`EncryptedControllerJob`]
+/// * `patch_values` - The parameters to use for the execution. The job will be run once for each
+///     given set of patch_values.
+/// * `client` - The [`Qcs`] client to use.
+/// * `execution_options` - The [`ExecutionOptions`] to use. If the connection strategy used
+///       is [`ConnectionStrategy::EndpointId`] then direct access to that endpoint
+///       overrides the `quantum_processor_id` parameter.
+///
+/// # Errors
+///
+/// * Returns a [`QpuApiError`] if:
+///     * Any of the jobs fail to be queued.
+///     * The provided `patch_values` iterator is empty.
+pub async fn submit_with_parameter_batch<'a, I>(
+    quantum_processor_id: Option<&str>,
+    program: EncryptedControllerJob,
+    patch_values: I,
+    client: &Qcs,
+    execution_options: &ExecutionOptions,
+) -> Result<Vec<JobId>, QpuApiError>
+where
+    I: IntoIterator<Item = &'a Parameters>,
+{
     #[cfg(feature = "tracing")]
     tracing::debug!(
         "submitting job to {:?} using options {:?}",
@@ -101,8 +149,15 @@ pub async fn submit(
         execution_options
     );
 
+    let mut patch_values = patch_values.into_iter().peekable();
+    if patch_values.peek().is_none() {
+        return Err(QpuApiError::EmptyPatchValues);
+    }
+
     let request = ExecuteControllerJobRequest {
-        execution_configurations: vec![params_into_job_execution_configuration(patch_values)],
+        execution_configurations: patch_values
+            .map(|params| params_into_job_execution_configuration(params))
+            .collect(),
         job: Some(execute_controller_job_request::Job::Encrypted(program)),
         target: execution_options.get_job_target(quantum_processor_id),
         options: execution_options.api_options().cloned(),
@@ -112,18 +167,15 @@ pub async fn submit(
         .get_controller_client(client, quantum_processor_id)
         .await?;
 
-    // we expect exactly one job ID since we only submit one execution configuration
-    let job_execution_id = controller_client
+    Ok(controller_client
         .execute_controller_job(request)
         .await
         .map_err(GrpcClientError::RequestFailed)?
         .into_inner()
         .job_execution_ids
-        .pop();
-
-    Ok(job_execution_id
+        .into_iter()
         .map(JobId)
-        .ok_or_else(|| GrpcClientError::ResponseEmpty("Job Execution ID".into()))?)
+        .collect())
 }
 
 /// Cancel all given jobs that have yet to begin executing.
@@ -621,6 +673,10 @@ pub enum QpuApiError {
     /// Error due to missing quantum processor ID and endpoint ID.
     #[error("A quantum processor ID must be provided if not connecting directly to an endpoint ID with ConnectionStrategy::EndpointId")]
     MissingQpuId,
+
+    /// Error due to user not providing patch values
+    #[error("Submitting a job requires at least one set of patch values")]
+    EmptyPatchValues,
 
     /// Error that can occur when controller service fails to execute a job
     #[error("The submitted job failed with status: {status}. {message}")]

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -77,6 +77,8 @@ impl From<String> for JobId {
 
 /// Execute compiled program on a QPU.
 ///
+/// See [`ExecuteControllerJobRequest`] for more details.
+///
 /// # Arguments
 /// * `quantum_processor_id` - The quantum processor to execute the job on. This parameter
 ///      is required unless using [`ConnectionStrategy::EndpointId`] in `execution_options`
@@ -110,10 +112,7 @@ pub async fn submit(
 
 /// Execute a compiled program on a QPU with multiple sets of `patch_values`.
 ///
-/// This action is *atomic* in that all jobs will be queued, or none of them will. On success, this
-/// function will return a vector of [`JobId`] where the length and order correspond to the
-/// `patch_values` given. However, note that execution in the order of given patch values is not
-/// guaranteed. If there is a failure to queue any of the jobs, then none will be queued.
+/// See [`ExecuteControllerJobRequest`] for more details.
 ///
 /// # Arguments
 /// * `quantum_processor_id` - The quantum processor to execute the job on. This parameter

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -121,7 +121,7 @@ pub async fn submit(
 ///      to target a specific endpoint ID.
 /// * `program` - The compiled program as an [`EncryptedControllerJob`]
 /// * `patch_values` - The parameters to use for the execution. The job will be run once for each
-///     given set of patch_values.
+///     given set of [`Parameters`].
 /// * `client` - The [`Qcs`] client to use.
 /// * `execution_options` - The [`ExecutionOptions`] to use. If the connection strategy used
 ///       is [`ConnectionStrategy::EndpointId`] then direct access to that endpoint
@@ -156,7 +156,7 @@ where
 
     let request = ExecuteControllerJobRequest {
         execution_configurations: patch_values
-            .map(|params| params_into_job_execution_configuration(params))
+            .map(params_into_job_execution_configuration)
             .collect(),
         job: Some(execute_controller_job_request::Job::Encrypted(program)),
         target: execution_options.get_job_target(quantum_processor_id),

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -166,7 +166,7 @@ def submit_with_parameter_batch(
     """
     ...
 
-def submit_with_parameter_batch_async(
+async def submit_with_parameter_batch_async(
     program: str,
     patch_values: Iterable[Mapping[str, Sequence[float]]],
     quantum_processor_id: Optional[str] = None,

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -175,7 +175,7 @@ def submit_with_parameter_batch_async(
 ) -> List[str]:
     """
     Execute a compiled program on a QPU with multiple sets of `patch_values`.
-    (async analog of `submit_with_paramater_batch`)
+    (async analog of `submit_with_parameter_batch`)
 
     This action is *atomic* in that all jobs will be queued, or none of them will. On success, this
     function will return a list of strings where the length and order correspond to the

--- a/crates/python/qcs_sdk/qpu/api.pyi
+++ b/crates/python/qcs_sdk/qpu/api.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Dict, List, Sequence, Mapping, Optional, Union, final
 
 from qcs_sdk.client import QCSClient
@@ -130,6 +131,71 @@ async def submit_async(
 
     :raises LoadClientError: If there is an issue loading the QCS Client configuration.
     :raises SubmissionError: If there was a problem submitting the program for execution.
+    """
+    ...
+
+def submit_with_parameter_batch(
+    program: str,
+    patch_values: Iterable[Mapping[str, Sequence[float]]],
+    quantum_processor_id: Optional[str] = None,
+    client: Optional[QCSClient] = None,
+    execution_options: Optional[ExecutionOptions] = None,
+) -> List[str]:
+    """
+    Execute a compiled program on a QPU with multiple sets of `patch_values`.
+
+    This action is *atomic* in that all jobs will be queued, or none of them will. On success, this
+    function will return a list of strings where the length and order correspond to the
+    `patch_values` given. However, note that execution in the order of given patch values is not
+    guaranteed. If there is a failure to queue any of the jobs, then none will be queued.
+
+    Submits an executable `program` to be run on the specified QPU.
+
+    :param program: An executable program (see `translate`).
+    :param patch_values: An iterable containing one ore more mapping of symbols to their desired values
+        (see `build_patch_values`).
+    :param quantum_processor_id: The ID of the quantum processor to run the executable on. This field is required, unless being used with the `ConnectionStrategy.endpoint_id()` execution option.
+    :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param execution_options: The ``ExecutionOptions`` to use. If the connection strategy option used is `ConnectionStrategy.endpoint_id("endpoint_id")`, then direct access to "endpoint_id" overrides the `quantum_processor_id` parameter.
+
+    :returns: The ID of the submitted job which can be used to fetch results
+
+    :raises LoadClientError: If there is an issue loading the QCS Client configuration.
+    :raises SubmissionError: If there was a problem submitting any of the jobs for execution, or if no
+        `patch_values` are given.
+    """
+    ...
+
+def submit_with_parameter_batch_async(
+    program: str,
+    patch_values: Iterable[Mapping[str, Sequence[float]]],
+    quantum_processor_id: Optional[str] = None,
+    client: Optional[QCSClient] = None,
+    execution_options: Optional[ExecutionOptions] = None,
+) -> List[str]:
+    """
+    Execute a compiled program on a QPU with multiple sets of `patch_values`.
+    (async analog of `submit_with_paramater_batch`)
+
+    This action is *atomic* in that all jobs will be queued, or none of them will. On success, this
+    function will return a list of strings where the length and order correspond to the
+    `patch_values` given. However, note that execution in the order of given patch values is not
+    guaranteed. If there is a failure to queue any of the jobs, then none will be queued.
+
+    Submits an executable `program` to be run on the specified QPU.
+
+    :param program: An executable program (see `translate`).
+    :param patch_values: An iterable containing one ore more mapping of symbols to their desired values
+        (see `build_patch_values`).
+    :param quantum_processor_id: The ID of the quantum processor to run the executable on. This field is required, unless being used with the `ConnectionStrategy.endpoint_id()` execution option.
+    :param client: The ``QCSClient`` to use. Creates one using environment configuration if unset - see https://docs.rigetti.com/qcs/references/qcs-client-configuration
+    :param execution_options: The ``ExecutionOptions`` to use. If the connection strategy option used is `ConnectionStrategy.endpoint_id("endpoint_id")`, then direct access to "endpoint_id" overrides the `quantum_processor_id` parameter.
+
+    :returns: The ID of the submitted job which can be used to fetch results
+
+    :raises LoadClientError: If there is an issue loading the QCS Client configuration.
+    :raises SubmissionError: If there was a problem submitting any of the jobs for execution, or if no
+        `patch_values` are given.
     """
     ...
 


### PR DESCRIPTION
closes #446 

I've decided to not implement this as part of the Executable API. The Executable API maintains state for a single set of parameters, so adding support for multiple sets would lead to a breaking change. 