### PR TITLE
open up tonic version range to include 0.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,9 @@ jobs:
   checks:
     name: Run Checks
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tonic-version: ['0.9.0', '0.10.0', '0.11.0']
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -35,6 +38,13 @@ jobs:
           args: --debug cargo-make
       - name: Install poetry
         uses: snok/install-poetry@v1
+      - name: Install dasel
+        run: |
+          curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+      - name: Pin dependency versions
+        run: |
+          dasel -f crates/lib/Cargo.toml put -t string -v "${{ matrix.tonic-version }}" "dependencies.tonic.version"
       - name: Run Rust CI
         uses: actions-rs/cargo@v1
         env:

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -41,7 +41,7 @@ tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 toml = "0.7.3"
 tracing = { version = "0.1", optional = true, features = ["log"] }
 uuid = { version = "1.2.1", features = ["v4"] }
-tonic = { version = "0.9.2", features = ["tls", "tls-roots"] }
+tonic = { version = ">=0.9.2,<12.0", features = ["tls", "tls-roots"] }
 zmq = { version = "0.10.0" }
 itertools = "0.11.0"
 derive_builder = "0.12.0"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -41,6 +41,8 @@ tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 toml = "0.7.3"
 tracing = { version = "0.1", optional = true, features = ["log"] }
 uuid = { version = "1.2.1", features = ["v4"] }
+# Note! (@kalzoo) If you move or update this line (the `tonic` dependency), also update the
+# corresponding GitHub action matrix entry (which tests multiple versions within the range).
 tonic = { version = ">=0.9.2,<12.0", features = ["tls", "tls-roots"] }
 zmq = { version = "0.10.0" }
 itertools = "0.11.0"


### PR DESCRIPTION
While `tonic` remains pre-1.0 and this is a sweep of major versions, they are all compatible with this package and can help resolve the confusing type errors which arise when consumers rely on distinct major versions of `tonic`.