### PR TITLE
feat: increase gRPC max message size from 4MB to 50MB

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["gRPC", ".."]
+doc-valid-idents = ["gRPC", "..", "JupyterLab"]

--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -22,6 +22,9 @@ pub use qcs_api_client_common::configuration::LoadError;
 pub use qcs_api_client_grpc::channel::Error as GrpcError;
 pub use qcs_api_client_openapi::apis::Error as OpenApiError;
 
+const DEFAULT_MAX_MESSAGE_ENCODING_SIZE: usize = 50 * 1024 * 1024;
+const DEFAULT_MAX_MESSAGE_DECODING_SIZE: usize = 50 * 1024 * 1024;
+
 /// A type alias for the underlying gRPC connection used by all gRPC clients within this library.
 /// It is public so that users can create gRPC clients with different APIs using a "raw" connection
 /// initialized by this library. This ensures that the exact Tonic version used for such clients
@@ -106,7 +109,9 @@ impl Qcs {
             wrap_channel_with_retry(wrap_channel_with(channel, self.get_config().clone()));
         #[cfg(feature = "grpc-web")]
         let service = wrap_channel_with_grpc_web(service);
-        Ok(TranslationClient::new(service))
+        Ok(TranslationClient::new(service)
+            .max_encoding_message_size(DEFAULT_MAX_MESSAGE_ENCODING_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_MESSAGE_DECODING_SIZE))
     }
 }
 

--- a/crates/lib/src/compiler/libquil.rs
+++ b/crates/lib/src/compiler/libquil.rs
@@ -12,7 +12,7 @@ use super::quilc::{self, NativeQuilMetadata};
 /// The errors that can arise when using libquil as a QVM client
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Error when calling libquil_sys::quilc
+    /// Error when calling [`libquil_sys::quilc`]
     #[error("error when calling libquil_sys: {0}")]
     Quilc(#[from] libquil_sys::quilc::Error),
     /// Error when serializing a program
@@ -24,7 +24,7 @@ pub enum Error {
     /// Error when casting u64 to u32
     #[error("error when casting u64 to u32: {0}")]
     U64Truncation(#[from] TryFromIntError),
-    /// Error when creating a CString
+    /// Error when creating a [`CString`]
     #[error("error when creating CString: {0}")]
     CString(#[from] NulError),
 }
@@ -202,14 +202,14 @@ mod test {
         assert_eq!(output.program.to_quil_or_debug(), EXPECTED_H0_OUTPUT);
     }
 
-    const BELL_STATE: &str = r##"DECLARE ro BIT[2]
+    const BELL_STATE: &str = r"DECLARE ro BIT[2]
 
 H 0
 CNOT 0 1
 
 MEASURE 0 ro[0]
 MEASURE 1 ro[1]
-"##;
+";
 
     #[tokio::test]
     async fn test_print_isa() {
@@ -228,7 +228,7 @@ MEASURE 1 ro[1]
                 CompilerOpts::default(),
             )
             .expect("Could not compile");
-        let mut results = crate::qvm::Execution::new(&output.program.to_quil_or_debug())
+        let mut results = qvm::Execution::new(&output.program.to_quil_or_debug())
             .unwrap()
             .run(
                 NonZeroU16::new(10).expect("value is non-zero"),

--- a/crates/lib/src/compiler/quilc.rs
+++ b/crates/lib/src/compiler/quilc.rs
@@ -228,7 +228,7 @@ pub enum CompilationError {
     Libquil(crate::compiler::libquil::Error),
     /// Errors during compilation when using RPCQ
     #[error("compilation error from RPCQ: {0}")]
-    Rpcq(crate::compiler::rpcq::Error),
+    Rpcq(rpcq::Error),
 }
 
 /// The response from quilc for a `quil_to_native_quil` request.
@@ -398,7 +398,7 @@ MEASURE 1 ro[1]
                 CompilerOpts::default(),
             )
             .expect("Could not compile");
-        let mut results = crate::qvm::Execution::new(&output.program.to_quil_or_debug())
+        let mut results = qvm::Execution::new(&output.program.to_quil_or_debug())
             .unwrap()
             .run(
                 NonZeroU16::new(10).expect("value is non-zero"),

--- a/crates/lib/src/qpu/rewrite_arithmetic.rs
+++ b/crates/lib/src/qpu/rewrite_arithmetic.rs
@@ -367,6 +367,8 @@ impl RewrittenProgram {
     }
 }
 
+pub(crate) type Substitutions = IndexSet<Expression>;
+
 #[cfg(test)]
 mod describe_rewrite_arithmetic {
     use std::str::FromStr;
@@ -559,5 +561,3 @@ SHIFT-PHASE 0 "rf" __SUBST[0]
         insta::assert_snapshot!(substitutions[0].to_quil_or_debug());
     }
 }
-
-pub(crate) type Substitutions = IndexSet<Expression>;

--- a/crates/python/src/execution_data.rs
+++ b/crates/python/src/execution_data.rs
@@ -111,7 +111,7 @@ impl PyExecutionData {
         ))
     }
 
-    pub fn __setstate__<'a>(&mut self, state: &PyBytes) -> PyResult<()> {
+    pub fn __setstate__(&mut self, state: &PyBytes) -> PyResult<()> {
         let execution_data: ExecutionData = serde_json::from_slice(state.as_bytes())
             .map_err(|e| PyRuntimeError::new_err(format!("failed to deserialize: {e}")))?;
         *self = PyExecutionData(execution_data);


### PR DESCRIPTION
Increases the gRPC max message size from 4MB (the `tonic` default) to 50MB. This is motivated by some users having hit the 4MB limit.

This MR also fixes a number of new clippy lints that were causing CI to fail.

Closes #467.