### PR TITLE
fix!: update qcs-api deps to use a >=9 version of jsonwebtoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,23 +753,22 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "winapi",
 ]
 
 [[package]]
@@ -2170,12 +2169,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "assert2-macros",
  "diff",
  "is-terminal",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -123,6 +123,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -301,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
+name = "bytemuck"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48814962d2fd604c50d2b9433c2a41a0ab567779ee2c02f7fba6eca1221f082"
 dependencies = [
  "cached_proc_macro_types",
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -561,8 +576,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -580,14 +605,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -605,7 +655,16 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.12.0",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro 0.20.0",
 ]
 
 [[package]]
@@ -614,10 +673,22 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -626,8 +697,18 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.12.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core 0.20.0",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -668,6 +749,27 @@ dependencies = [
  "jwalk",
  "log",
  "walkdir",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -757,6 +859,20 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.14",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1347,6 +1463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "insta"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,13 +1556,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
+ "js-sys",
  "pem",
- "ring 0.16.20",
+ "ring 0.17.8",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -1582,6 +1705,16 @@ dependencies = [
  "pkg-config",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
 ]
 
 [[package]]
@@ -2039,6 +2172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2268,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi 1.0.1",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,11 +2298,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -2277,6 +2440,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "version_check",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -2475,7 +2651,7 @@ dependencies = [
  "async-trait",
  "built",
  "cached",
- "derive_builder",
+ "derive_builder 0.12.0",
  "enum-as-inner",
  "erased-serde",
  "float-cmp",
@@ -2531,22 +2707,25 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-common"
-version = "0.7.14"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c56fa367070074f32143b4adef924af1441faa86e835f45371e14801884d14"
+checksum = "040552f233992abe94376304cf17dab2d79ff62d4a9ee986d75efe3d19337f57"
 dependencies = [
  "async-trait",
  "backoff",
+ "derive_builder 0.20.0",
+ "figment",
  "futures",
  "home",
  "http",
  "jsonwebtoken",
  "reqwest",
  "serde",
+ "shellexpand",
  "thiserror",
  "time",
  "tokio",
- "toml 0.7.8",
+ "toml 0.8.14",
  "tracing",
  "url",
  "urlpattern",
@@ -2554,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-grpc"
-version = "0.7.16"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01247ae1b0523e058007edb0132cd40915452b8b4dc669d68156e187740ead70"
+checksum = "eb755cd59b1b3ce99abe52ff6898ad74ca26463e94300c103cafaac4f345c4f3"
 dependencies = [
  "backoff",
  "http",
@@ -2587,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "qcs-api-client-openapi"
-version = "0.8.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d7172e79b083a85c911917c03be58eda083b36ea7575db685d21aa2fa99b41"
+checksum = "008d06c4051dd4b3e7d5b6c1f31457c68384f8f36b05b304de6059bbd81c6128"
 dependencies = [
  "anyhow",
  "qcs-api-client-common",
@@ -2733,6 +2912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -3281,6 +3471,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3573,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -4042,6 +4247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4574,6 +4788,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4869,9 +4869,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ resolver = "2"
 
 [workspace.dependencies]
 qcs-api = "0.2.1"
-qcs-api-client-common = "0.7.14"
-qcs-api-client-grpc = "0.7.16"
-qcs-api-client-openapi = "0.8.15"
+qcs-api-client-common = "0.8.4"
+qcs-api-client-grpc = "0.8.4"
+qcs-api-client-openapi = "0.9.4"
 serde_json = "1.0.86"
 thiserror = "1.0.57"
 tokio = "1.36.0"

--- a/crates/lib/examples/delayed_job_retrieval.rs
+++ b/crates/lib/examples/delayed_job_retrieval.rs
@@ -11,7 +11,7 @@ MEASURE 0 ro[0]
 const QUANTUM_PROCESSOR_ID: &str = "Aspen-M-3";
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/examples/execute.rs
+++ b/crates/lib/examples/execute.rs
@@ -12,7 +12,7 @@ MEASURE 1 ro[1]
 "#;
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/examples/local.rs
+++ b/crates/lib/examples/local.rs
@@ -13,7 +13,7 @@ MEASURE 1 ro[1]
 "#;
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/examples/parametric_compilation.rs
+++ b/crates/lib/examples/parametric_compilation.rs
@@ -20,7 +20,7 @@ RX(-pi / 2) 0
 MEASURE 0 ro[0]
 "#;
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/examples/quil_t.rs
+++ b/crates/lib/examples/quil_t.rs
@@ -13,7 +13,7 @@ DELAY 0 "rf" 1e-6
 MEASURE 0 ro
 "#;
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -52,23 +52,17 @@ pub struct Qcs {
 
 impl Qcs {
     /// Create a [`Qcs`] and initialize it with the user's default [`ClientConfiguration`]
-    ///
-    /// # Panics
-    /// - if the default configuration cannot be loaded
     #[must_use]
     pub fn load() -> Self {
-        let config = if let Ok(config) = ClientConfiguration::load_default() {
-            config
+        if let Ok(config) = ClientConfiguration::load_default() {
+            Self::with_config(config)
         } else {
             #[cfg(feature = "tracing")]
             tracing::info!(
                 "No QCS client configuration found. QPU data and QCS will be inaccessible and only generic QVMs will be available for execution"
             );
-            ClientConfiguration::builder()
-                .build()
-                .expect("builder should be valid with all defaults")
-        };
-        Self::with_config(config)
+            Self::default()
+        }
     }
 
     /// Create a [`Qcs`] and initialize it with the given [`ClientConfiguration`]

--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -4,22 +4,22 @@
 
 use std::time::Duration;
 
-use qcs_api_client_common::configuration::{ClientConfiguration, RefreshError};
+use qcs_api_client_common::configuration::{ClientConfiguration, TokenError};
 #[cfg(feature = "grpc-web")]
-use qcs_api_client_grpc::channel::{wrap_channel_with_grpc_web, GrpcWebWrapperLayerService};
+use qcs_api_client_grpc::tonic::{wrap_channel_with_grpc_web, GrpcWebWrapperLayerService};
 use qcs_api_client_grpc::{
-    channel::{
+    services::translation::translation_client::TranslationClient,
+    tonic::{
         get_channel, parse_uri, wrap_channel_with, wrap_channel_with_retry, RefreshService,
         RetryService,
     },
-    services::translation::translation_client::TranslationClient,
 };
 use qcs_api_client_openapi::apis::configuration::Configuration as OpenApiConfiguration;
 use tonic::transport::Channel;
 use tonic::Status;
 
 pub use qcs_api_client_common::configuration::LoadError;
-pub use qcs_api_client_grpc::channel::Error as GrpcError;
+pub use qcs_api_client_grpc::tonic::Error as GrpcError;
 pub use qcs_api_client_openapi::apis::Error as OpenApiError;
 
 const DEFAULT_MAX_MESSAGE_ENCODING_SIZE: usize = 50 * 1024 * 1024;
@@ -45,22 +45,24 @@ pub type GrpcConnection =
 pub(crate) static DEFAULT_HTTP_API_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A client providing helper functionality for accessing QCS APIs
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Qcs {
     config: ClientConfiguration,
 }
 
 impl Qcs {
     /// Create a [`Qcs`] and initialize it with the user's default [`ClientConfiguration`]
-    pub async fn load() -> Self {
-        let config = if let Ok(config) = ClientConfiguration::load_default().await {
+    pub fn load() -> Self {
+        let config = if let Ok(config) = ClientConfiguration::load_default() {
             config
         } else {
             #[cfg(feature = "tracing")]
             tracing::info!(
                 "No QCS client configuration found. QPU data and QCS will be inaccessible and only generic QVMs will be available for execution"
             );
-            ClientConfiguration::default()
+            ClientConfiguration::builder()
+                .build()
+                .expect("builder should be valid with all defaults")
         };
         Self::with_config(config)
     }
@@ -78,9 +80,7 @@ impl Qcs {
     /// A [`LoadError`] will be returned if QCS credentials are
     /// not correctly configured or the given profile is not defined.
     pub async fn with_profile(profile: String) -> Result<Qcs, LoadError> {
-        ClientConfiguration::load_profile(profile)
-            .await
-            .map(Self::with_config)
+        ClientConfiguration::load_profile(profile).map(Self::with_config)
     }
 
     /// Return a reference to the underlying [`ClientConfiguration`] with all settings parsed and resolved from configuration sources.
@@ -95,14 +95,14 @@ impl Qcs {
 
     pub(crate) fn get_translation_client(
         &self,
-    ) -> Result<TranslationClient<GrpcConnection>, GrpcError<RefreshError>> {
+    ) -> Result<TranslationClient<GrpcConnection>, GrpcError<TokenError>> {
         self.get_translation_client_with_endpoint(self.get_config().grpc_api_url())
     }
 
     pub(crate) fn get_translation_client_with_endpoint(
         &self,
         translation_grpc_endpoint: &str,
-    ) -> Result<TranslationClient<GrpcConnection>, GrpcError<RefreshError>> {
+    ) -> Result<TranslationClient<GrpcConnection>, GrpcError<TokenError>> {
         let uri = parse_uri(translation_grpc_endpoint)?;
         let channel = get_channel(uri)?;
         let service =
@@ -112,6 +112,16 @@ impl Qcs {
         Ok(TranslationClient::new(service)
             .max_encoding_message_size(DEFAULT_MAX_MESSAGE_ENCODING_SIZE)
             .max_decoding_message_size(DEFAULT_MAX_MESSAGE_DECODING_SIZE))
+    }
+}
+
+impl Default for Qcs {
+    fn default() -> Self {
+        Self::with_config(
+            ClientConfiguration::builder()
+                .build()
+                .expect("builder should be valid with all defaults"),
+        )
     }
 }
 
@@ -128,7 +138,7 @@ pub enum GrpcClientError {
 
     /// Error due to `gRPC` error
     #[error("gRPC error: {0}")]
-    GrpcError(#[from] GrpcError<RefreshError>),
+    GrpcError(#[from] GrpcError<TokenError>),
 }
 
 /// Errors that may occur while trying to use an `OpenAPI` client

--- a/crates/lib/src/client.rs
+++ b/crates/lib/src/client.rs
@@ -52,6 +52,10 @@ pub struct Qcs {
 
 impl Qcs {
     /// Create a [`Qcs`] and initialize it with the user's default [`ClientConfiguration`]
+    ///
+    /// # Panics
+    /// - if the default configuration cannot be loaded
+    #[must_use]
     pub fn load() -> Self {
         let config = if let Ok(config) = ClientConfiguration::load_default() {
             config
@@ -79,7 +83,7 @@ impl Qcs {
     ///
     /// A [`LoadError`] will be returned if QCS credentials are
     /// not correctly configured or the given profile is not defined.
-    pub async fn with_profile(profile: String) -> Result<Qcs, LoadError> {
+    pub fn with_profile(profile: String) -> Result<Qcs, LoadError> {
         ClientConfiguration::load_profile(profile).map(Self::with_config)
     }
 

--- a/crates/lib/src/compiler/quilc.rs
+++ b/crates/lib/src/compiler/quilc.rs
@@ -358,7 +358,7 @@ mod tests {
     }
 
     async fn rpcq_client() -> rpcq::Client {
-        let qcs = Qcs::load().await;
+        let qcs = Qcs::load();
         let endpoint = qcs.get_config().quilc_url();
         rpcq::Client::new(endpoint).unwrap()
     }
@@ -387,7 +387,7 @@ MEASURE 1 ro[1]
 
     #[tokio::test]
     async fn run_compiled_bell_state_on_qvm() {
-        let client = Qcs::load().await;
+        let client = Qcs::load();
         let client = qvm::http::HttpClient::from(&client);
         let output = rpcq_client()
             .await

--- a/crates/lib/src/diagnostics.rs
+++ b/crates/lib/src/diagnostics.rs
@@ -38,7 +38,7 @@ struct Diagnostics {
 
 impl Diagnostics {
     async fn gather() -> Self {
-        let client = Qcs::load().await;
+        let client = Qcs::load();
 
         let (qcs, qvm) = futures::future::join(
             QcsApiDiagnostics::gather(&client),

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -301,7 +301,7 @@ impl<'executable> Executable<'executable, '_> {
     /// Get a reference to the [`Qcs`] client used by the executable.
     ///
     /// If one has not been set, a default client is loaded, set, and returned.
-    pub async fn qcs_client(&mut self) -> Arc<Qcs> {
+    pub fn qcs_client(&mut self) -> Arc<Qcs> {
         if let Some(client) = &self.qcs_client {
             client.clone()
         } else {
@@ -413,7 +413,7 @@ impl<'execution> Executable<'_, 'execution> {
             self.quil.clone(),
             self.shots,
             id,
-            self.qcs_client().await,
+            self.qcs_client(),
             self.quilc_client.clone(),
             self.compiler_options,
         )
@@ -864,7 +864,7 @@ mod describe_qpu_for_id {
                 "".into(),
                 shots,
                 "Aspen-M-3".into(),
-                exe.qcs_client().await,
+                exe.qcs_client(),
                 exe.quilc_client.clone(),
                 CompilerOpts::default(),
             )

--- a/crates/lib/src/executable.rs
+++ b/crates/lib/src/executable.rs
@@ -44,7 +44,7 @@ use quil_rs::program::ProgramError;
 /// async fn main() {
 ///     use std::num::NonZeroU16;
 ///     use qcs::qvm;
-///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load().await);
+///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load());
 ///     let mut result = Executable::from_quil(PROGRAM).with_qcs_client(Qcs::default()).with_shots(NonZeroU16::new(4).unwrap()).execute_on_qvm(&qvm_client).await.unwrap();
 ///     // "ro" is the only source read from by default if you don't specify a .read_from()
 ///
@@ -158,7 +158,7 @@ impl<'executable> Executable<'executable, '_> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load().await);
+    ///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load());
     ///     let mut result = Executable::from_quil(PROGRAM)
     ///         .with_qcs_client(Qcs::default()) // Unnecessary if you have ~/.qcs/settings.toml
     ///         .read_from("first")
@@ -228,7 +228,7 @@ impl<'executable> Executable<'executable, '_> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load().await);
+    ///     let qvm_client = qvm::http::HttpClient::from(&Qcs::load());
     ///     let mut exe = Executable::from_quil(PROGRAM)
     ///         .with_qcs_client(Qcs::default()) // Unnecessary if you have ~/.qcs/settings.toml
     ///         .read_from("theta");
@@ -305,7 +305,7 @@ impl<'executable> Executable<'executable, '_> {
         if let Some(client) = &self.qcs_client {
             client.clone()
         } else {
-            let client = Arc::new(Qcs::load().await);
+            let client = Arc::new(Qcs::load());
             self.qcs_client = Some(client.clone());
             client
         }
@@ -804,7 +804,7 @@ mod describe_get_config {
     use crate::{compiler::rpcq, Executable};
 
     async fn quilc_client() -> rpcq::Client {
-        let qcs = Qcs::load().await;
+        let qcs = Qcs::load();
         let endpoint = qcs.get_config().quilc_url();
         rpcq::Client::new(endpoint).unwrap()
     }
@@ -835,7 +835,7 @@ mod describe_qpu_for_id {
     use crate::{client::Qcs, Executable};
 
     async fn quilc_client() -> rpcq::Client {
-        let qcs = Qcs::load().await;
+        let qcs = Qcs::load();
         let endpoint = qcs.get_config().quilc_url();
         rpcq::Client::new(endpoint).unwrap()
     }
@@ -844,7 +844,7 @@ mod describe_qpu_for_id {
     async fn it_refreshes_auth_token() {
         // Default config has no auth, so it should try to refresh
         let mut exe = Executable::from_quil("")
-            .with_qcs_client(Qcs::default())
+            .with_qcs_client(Qcs::load())
             .with_quilc_client(Some(quilc_client().await));
         let result = exe.qpu_for_id("blah").await;
         let Err(err) = result else {

--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -5,12 +5,11 @@ use std::{convert::TryFrom, fmt, time::Duration};
 
 use cached::proc_macro::cached;
 use derive_builder::Builder;
-use qcs_api_client_common::configuration::RefreshError;
+use qcs_api_client_common::configuration::TokenError;
 #[cfg(feature = "grpc-web")]
-use qcs_api_client_grpc::channel::wrap_channel_with_grpc_web;
-pub use qcs_api_client_grpc::channel::Error as GrpcError;
+use qcs_api_client_grpc::tonic::wrap_channel_with_grpc_web;
+pub use qcs_api_client_grpc::tonic::Error as GrpcError;
 use qcs_api_client_grpc::{
-    channel::{parse_uri, wrap_channel_with, wrap_channel_with_retry},
     get_channel_with_timeout,
     models::controller::{
         controller_job_execution_result, data_value::Value, ControllerJobExecutionResult,
@@ -22,6 +21,7 @@ use qcs_api_client_grpc::{
         CancelControllerJobsRequest, ExecuteControllerJobRequest,
         ExecutionOptions as InnerApiExecutionOptions, GetControllerJobResultsRequest,
     },
+    tonic::{parse_uri, wrap_channel_with, wrap_channel_with_retry},
 };
 pub use qcs_api_client_openapi::apis::Error as OpenApiError;
 use qcs_api_client_openapi::apis::{
@@ -644,7 +644,7 @@ async fn get_default_endpoint(
 pub enum QpuApiError {
     /// Error due to a bad gRPC configuration
     #[error("Error configuring gRPC request: {0}")]
-    GrpcError(#[from] GrpcError<RefreshError>),
+    GrpcError(#[from] GrpcError<TokenError>),
 
     /// Error due to missing gRPC endpoint for endpoint ID
     #[error("Missing gRPC endpoint for endpoint ID: {0}")]

--- a/crates/lib/src/qvm/execution.rs
+++ b/crates/lib/src/qvm/execution.rs
@@ -82,7 +82,7 @@ mod describe_execution {
     use crate::{client::Qcs, qvm};
 
     async fn qvm_client() -> qvm::http::HttpClient {
-        let qcs = Qcs::load().await;
+        let qcs = Qcs::load();
         qvm::http::HttpClient::from(&qcs)
     }
 

--- a/crates/lib/tests/basic_qvm.rs
+++ b/crates/lib/tests/basic_qvm.rs
@@ -17,13 +17,13 @@ MEASURE 1 second
 "##;
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }
 
 async fn qvm_client() -> qvm::http::HttpClient {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     qvm::http::HttpClient::from(&qcs)
 }
 
@@ -33,7 +33,7 @@ async fn test_bell_state() {
 
     let data = Executable::from_quil(PROGRAM)
         .with_quilc_client(Some(quilc_client().await))
-        .with_qcs_client(Qcs::load().await)
+        .with_qcs_client(Qcs::load())
         .with_shots(shots)
         .read_from("first")
         .read_from("second")

--- a/crates/lib/tests/mocked_qpu.rs
+++ b/crates/lib/tests/mocked_qpu.rs
@@ -64,7 +64,7 @@ async fn setup() {
 }
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }

--- a/crates/lib/tests/parametric_compilation.rs
+++ b/crates/lib/tests/parametric_compilation.rs
@@ -17,13 +17,13 @@ MEASURE 0 ro[0]
 "#;
 
 async fn quilc_client() -> rpcq::Client {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     let endpoint = qcs.get_config().quilc_url();
     rpcq::Client::new(endpoint).unwrap()
 }
 
 async fn qvm_client() -> qvm::http::HttpClient {
-    let qcs = Qcs::load().await;
+    let qcs = Qcs::load();
     qvm::http::HttpClient::from(&qcs)
 }
 

--- a/crates/lib/tests/qvm_api.rs
+++ b/crates/lib/tests/qvm_api.rs
@@ -22,7 +22,7 @@ MEASURE 1 ro[1]
 "##;
 
 async fn http_qvm_client() -> HttpClient {
-    let qcs_client = Qcs::load().await;
+    let qcs_client = Qcs::load();
     HttpClient::from(&qcs_client)
 }
 

--- a/crates/python/qcs_sdk/client.pyi
+++ b/crates/python/qcs_sdk/client.pyi
@@ -46,22 +46,6 @@ class QCSClient:
         for more details.
         """
         ...
-    @staticmethod
-    async def load_async(
-        profile_name: Optional[str] = None,
-    ) -> "QCSClient":
-        """
-        Create a `QCSClient` configuration using an environment-based configuration.
-        (async analog of `QCSClient.load`)
-
-        :param profile_name: The QCS setting's profile name to use. If `None`, the default value configured in your environment is used.
-
-        :raises `LoadClientError`: If there is an issue loading the profile defails from the environment.
-
-        See the [QCS documentation](https://docs.rigetti.com/qcs/references/qcs-client-configuration#environment-variables-and-configuration-files)
-        for more details.
-        """
-        ...
     @property
     def api_url(self) -> str:
         """URL to access the QCS API."""
@@ -108,12 +92,14 @@ class QCSClientTokens:
         cls,
         bearer_access_token: str,
         refresh_token: str,
+        auth_server: Optional[QCSClientAuthServer] = None,
     ) -> "QCSClientTokens":
         """
         Manually define authentication session tokens.
 
         :param bearer_access_token: The session token from an OAuth issuer.
         :param refresh_token: A credential to refresh the bearer_access_token when it expires.
+        :param auth_server: The OAuth server configuration. If `None`, default values are loaded.
         """
         ...
     @property
@@ -124,3 +110,7 @@ class QCSClientTokens:
     def refresh_token(self) -> Optional[str]: ...
     @refresh_token.setter
     def refresh_token(self, value: Optional[str]): ...
+    @property
+    def auth_server(self) -> Optional[QCSClientAuthServer]: ...
+    @auth_server.setter
+    def auth_server(self, value: Optional[QCSClientAuthServer]): ...

--- a/crates/python/src/client.rs
+++ b/crates/python/src/client.rs
@@ -1,11 +1,11 @@
 use qcs_api_client_common::configuration::{
-    AuthServer, BuildError, ClientConfigurationBuilder, Tokens,
+    AuthServer, ClientConfigurationBuilder, ClientConfigurationBuilderError, Tokens,
 };
 use rigetti_pyo3::{
     create_init_submodule, py_wrap_data_struct, py_wrap_error, py_wrap_type,
     pyo3::{
-        conversion::IntoPy, exceptions::PyRuntimeError, pyclass, pyclass::CompareOp, pymethods,
-        types::PyString, FromPyObject, Py, PyAny, PyObject, PyResult, Python,
+        conversion::IntoPy, exceptions::PyRuntimeError, pyclass::CompareOp, pymethods,
+        types::PyString, Py, PyAny, PyObject, PyResult, Python,
     },
     wrap_error, ToPythonError,
 };
@@ -29,7 +29,7 @@ create_init_submodule! {
 wrap_error!(RustLoadClientError(client::LoadError));
 py_wrap_error!(client, RustLoadClientError, LoadClientError, PyRuntimeError);
 
-wrap_error!(RustBuildClientError(BuildError));
+wrap_error!(RustBuildClientError(ClientConfigurationBuilderError));
 
 py_wrap_error!(
     client,
@@ -38,54 +38,68 @@ py_wrap_error!(
     PyRuntimeError
 );
 
-/// The fields on qcs_api_client_common::client::AuthServer are not public.
-#[pyclass]
-#[pyo3(name = "QCSClientAuthServer")]
-#[derive(FromPyObject)]
-pub struct PyQcsClientAuthServer {
-    #[pyo3(get, set)]
-    pub client_id: Option<String>,
-    #[pyo3(get, set)]
-    pub issuer: Option<String>,
-}
-
-impl From<PyQcsClientAuthServer> for AuthServer {
-    fn from(value: PyQcsClientAuthServer) -> Self {
-        let mut auth_server = AuthServer::default();
-        if let Some(client_id) = value.client_id {
-            auth_server = auth_server.set_client_id(client_id);
-        }
-        if let Some(issuer) = value.issuer {
-            auth_server = auth_server.set_issuer(issuer);
-        }
-        auth_server
-    }
-}
+// The fields on qcs_api_client_common::client::AuthServer are not public.
+py_wrap_type!(
+    PyQcsClientAuthServer(AuthServer) as "QCSClientAuthServer"
+);
 
 #[pymethods]
 impl PyQcsClientAuthServer {
     #[new]
     #[pyo3(signature = (client_id = None, issuer = None))]
     pub fn new(client_id: Option<String>, issuer: Option<String>) -> Self {
-        Self { client_id, issuer }
+        let mut auth_server = AuthServer::default();
+        if let Some(client_id) = client_id {
+            auth_server.set_client_id(client_id);
+        }
+        if let Some(issuer) = issuer {
+            auth_server.set_issuer(issuer);
+        }
+        Self(auth_server)
+    }
+
+    #[getter(client_id)]
+    fn get_client_id(&self) -> String {
+        self.0.client_id().to_string()
+    }
+
+    #[setter(client_id)]
+    fn set_client_id(&mut self, value: String) {
+        self.0.set_client_id(value);
+    }
+
+    #[getter(issuer)]
+    fn get_issuer(&self) -> String {
+        self.0.issuer().to_string()
+    }
+
+    #[setter(issuer)]
+    fn set_issuer(&mut self, value: String) {
+        self.0.set_issuer(value);
     }
 }
 
 py_wrap_data_struct! {
     PyQcsClientTokens(Tokens) as "QCSClientTokens" {
-        bearer_access_token: Option<String> => Option<Py<PyString>>,
-        refresh_token: Option<String> => Option<Py<PyString>>
+        bearer_access_token: String => Py<PyString>,
+        refresh_token: String => Py<PyString>,
+        auth_server: AuthServer => PyQcsClientAuthServer
     }
 }
 
 #[pymethods]
 impl PyQcsClientTokens {
     #[new]
-    #[pyo3(signature = (bearer_access_token = None, refresh_token = None))]
-    pub fn new(bearer_access_token: Option<String>, refresh_token: Option<String>) -> Self {
+    #[pyo3(signature = (bearer_access_token, refresh_token, auth_server = None))]
+    pub fn new(
+        bearer_access_token: String,
+        refresh_token: String,
+        auth_server: Option<PyQcsClientAuthServer>,
+    ) -> Self {
         Self(Tokens {
             bearer_access_token,
             refresh_token,
+            auth_server: auth_server.map(Into::into).unwrap_or_default(),
         })
     }
 }
@@ -98,7 +112,7 @@ impl PyQcsClient {
     pub(crate) async fn get_or_create_client(client: Option<Self>) -> Qcs {
         match client {
             Some(client) => client.into(),
-            None => Qcs::load().await,
+            None => Qcs::load(),
         }
     }
 
@@ -109,7 +123,7 @@ impl PyQcsClient {
                 .map(PyQcsClient)
                 .map_err(RustLoadClientError)
                 .map_err(RustLoadClientError::to_py_err)?,
-            None => Self(Qcs::load().await),
+            None => Self(Qcs::load()),
         })
     }
 }
@@ -142,22 +156,22 @@ impl PyQcsClient {
     ) -> PyResult<Self> {
         let mut builder = ClientConfigurationBuilder::default();
         if let Some(tokens) = tokens {
-            builder = builder.set_tokens(tokens.into());
+            builder.tokens(Some(tokens.into()));
         }
         if let Some(api_url) = api_url {
-            builder = builder.set_api_url(api_url);
+            builder.api_url(api_url);
         }
         if let Some(auth_server) = auth_server {
-            builder = builder.set_auth_server(auth_server.into());
+            builder.auth_server(auth_server.into());
         }
         if let Some(grpc_api_url) = grpc_api_url {
-            builder = builder.set_grpc_api_url(grpc_api_url);
+            builder.grpc_api_url(grpc_api_url);
         }
         if let Some(quilc_url) = quilc_url {
-            builder = builder.set_quilc_url(quilc_url);
+            builder.quilc_url(quilc_url);
         }
         if let Some(qvm_url) = qvm_url {
-            builder = builder.set_qvm_url(qvm_url);
+            builder.qvm_url(qvm_url);
         }
         let client = builder
             .build()

--- a/crates/python/src/client.rs
+++ b/crates/python/src/client.rs
@@ -107,21 +107,11 @@ py_wrap_type! {
 }
 
 impl PyQcsClient {
-    pub(crate) async fn get_or_create_client(client: Option<Self>) -> Qcs {
+    pub(crate) fn get_or_create_client(client: Option<Self>) -> Qcs {
         match client {
             Some(client) => client.into(),
             None => Qcs::load(),
         }
-    }
-
-    fn load(profile_name: Option<String>) -> PyResult<Self> {
-        Ok(match profile_name {
-            Some(profile_name) => Qcs::with_profile(profile_name)
-                .map(PyQcsClient)
-                .map_err(RustLoadClientError)
-                .map_err(RustLoadClientError::to_py_err)?,
-            None => Self(Qcs::load()),
-        })
     }
 }
 
@@ -181,9 +171,14 @@ impl PyQcsClient {
 
     #[staticmethod]
     #[pyo3(signature = (/, profile_name = None))]
-    #[pyo3(name = "load")]
-    pub fn py_load(_: Python<'_>, profile_name: Option<String>) -> PyResult<Self> {
-        Self::load(profile_name)
+    fn load(profile_name: Option<String>) -> PyResult<Self> {
+        Ok(match profile_name {
+            Some(profile_name) => Qcs::with_profile(profile_name)
+                .map(PyQcsClient)
+                .map_err(RustLoadClientError)
+                .map_err(RustLoadClientError::to_py_err)?,
+            None => Self(Qcs::load()),
+        })
     }
 
     #[getter]

--- a/crates/python/src/client.rs
+++ b/crates/python/src/client.rs
@@ -5,14 +5,12 @@ use rigetti_pyo3::{
     create_init_submodule, py_wrap_data_struct, py_wrap_error, py_wrap_type,
     pyo3::{
         conversion::IntoPy, exceptions::PyRuntimeError, pyclass::CompareOp, pymethods,
-        types::PyString, Py, PyAny, PyObject, PyResult, Python,
+        types::PyString, Py, PyObject, PyResult, Python,
     },
     wrap_error, ToPythonError,
 };
 
 use qcs::client::{self, Qcs};
-
-use crate::py_sync::{py_async, py_sync};
 
 create_init_submodule! {
     classes: [
@@ -116,10 +114,9 @@ impl PyQcsClient {
         }
     }
 
-    async fn load(profile_name: Option<String>) -> PyResult<Self> {
+    fn load(profile_name: Option<String>) -> PyResult<Self> {
         Ok(match profile_name {
             Some(profile_name) => Qcs::with_profile(profile_name)
-                .await
                 .map(PyQcsClient)
                 .map_err(RustLoadClientError)
                 .map_err(RustLoadClientError::to_py_err)?,
@@ -185,15 +182,8 @@ impl PyQcsClient {
     #[staticmethod]
     #[pyo3(signature = (/, profile_name = None))]
     #[pyo3(name = "load")]
-    pub fn py_load(py: Python<'_>, profile_name: Option<String>) -> PyResult<Self> {
-        py_sync!(py, Self::load(profile_name))
-    }
-
-    #[staticmethod]
-    #[pyo3(signature = (/, profile_name = None))]
-    #[pyo3(name = "load_async")]
-    pub fn py_load_async(py: Python<'_>, profile_name: Option<String>) -> PyResult<&PyAny> {
-        py_async!(py, Self::load(profile_name))
+    pub fn py_load(_: Python<'_>, profile_name: Option<String>) -> PyResult<Self> {
+        Self::load(profile_name)
     }
 
     #[getter]

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -91,7 +91,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         execution_options: Option<PyExecutionOptions>,
     ) -> PyResult<String> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         // Is there a better way to map these patch_values keys? This
         // negates the whole purpose of [`submit`] using `Box<str>`,
@@ -125,7 +125,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         execution_options: Option<PyExecutionOptions>,
     ) -> PyResult<Vec<String>> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         let patch_values: Vec<HashMap<Box<str>, Vec<f64>>> = patch_values
             .into_iter()
@@ -318,7 +318,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         execution_options: Option<PyExecutionOptions>,
     ) -> PyResult<()> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         qcs::qpu::api::cancel_jobs(
             job_ids.into_iter().map(|id| id.into()).collect(),
@@ -342,7 +342,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         execution_options: Option<PyExecutionOptions>,
     ) -> PyResult<()> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         qcs::qpu::api::cancel_job(
             job_id.into(),
@@ -367,7 +367,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         execution_options: Option<PyExecutionOptions>
     ) -> PyResult<ExecutionResults> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         let results = qcs::qpu::api::retrieve_results(job_id.into(), quantum_processor_id.as_deref(), &client, execution_options.unwrap_or_default().as_inner())
             .await

--- a/crates/python/src/qpu/isa.rs
+++ b/crates/python/src/qpu/isa.rs
@@ -149,7 +149,7 @@ py_function_sync_async! {
         quantum_processor_id: String,
         client: Option<PyQcsClient>,
     ) -> PyResult<PyInstructionSetArchitecture> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
 
         get_isa(&quantum_processor_id, &client)
             .await

--- a/crates/python/src/qpu/mod.rs
+++ b/crates/python/src/qpu/mod.rs
@@ -53,7 +53,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         timeout: Option<f64>,
     ) -> PyResult<Vec<String>> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
         let timeout = timeout.map(Duration::from_secs_f64);
         qcs::qpu::list_quantum_processors(&client, timeout)
             .await

--- a/crates/python/src/qpu/translation.rs
+++ b/crates/python/src/qpu/translation.rs
@@ -38,7 +38,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         timeout: Option<f64>,
     ) -> PyResult<String> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
         let timeout = timeout.map(Duration::from_secs_f64);
         qcs::qpu::translation::get_quilt_calibrations(quantum_processor_id, &client, timeout)
             .await.map_err(RustTranslationError::from).map_err(RustTranslationError::to_py_err)
@@ -187,7 +187,7 @@ py_function_sync_async! {
         client: Option<PyQcsClient>,
         translation_options: Option<PyTranslationOptions>,
     ) -> PyResult<PyTranslationResult> {
-        let client = PyQcsClient::get_or_create_client(client).await;
+        let client = PyQcsClient::get_or_create_client(client);
         let translation_options = translation_options.map(|opts| opts.as_inner().clone());
         let result =
             qcs::qpu::translation::translate(&quantum_processor_id, &native_quil, num_shots, &client, translation_options)

--- a/crates/python/tests/test_client.py
+++ b/crates/python/tests/test_client.py
@@ -28,9 +28,10 @@ async def test_client_empty_profile_is_default(default_client: QCSClient):
     """The profile "empty" is configured to be similar to a default client."""
     client = QCSClient.load(profile_name="empty")
 
-    assert client == default_client
-
-    assert client == await QCSClient.load_async(profile_name="empty")
+    assert client.api_url == default_client.api_url
+    assert client.grpc_api_url == default_client.grpc_api_url
+    assert client.quilc_url == default_client.quilc_url
+    assert client.qvm_url == default_client.qvm_url
 
 
 @pytest.mark.not_qcs_session
@@ -45,7 +46,7 @@ def test_client_default_profile_is_not_empty(default_client: QCSClient):
 def test_client_broken_raises():
     """Using a profile with broken configuration should surface the underlying error."""
     with pytest.raises(
-        LoadClientError, match=r"Expected auth server .* but it didn't exist"
+        LoadClientError, match=r"Expected auth server .* but it does not exist"
     ):
         QCSClient.load(profile_name="broken")
 

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,7 @@ allow = [
   "BSD-3-Clause",
   "Unicode-DFS-2016",
   "Unicode-3.0",
+  "MPL-2.0",
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses

--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,6 @@ allow = [
   "BSD-3-Clause",
   "Unicode-DFS-2016",
   "Unicode-3.0",
-  "MPL-2.0",
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
This will close #482

If you add the following to `Cargo.toml`, which is done during wheel publishing

```toml
[patch.crates-io]
hyper-proxy = { git = "https://github.com/rigetti/hyper-proxy" }
```

You'll see there's no dependency on the old ring version anymore
```sh
$ cargo tree -i ring@0.16.20

error: package ID specification `ring@0.16.20` did not match any packages
Did you mean one of these?

  ring@0.17.8
```