### PR TITLE
fix: ignore context extraction failure

### DIFF
--- a/crates/python/src/compiler/quilc.rs
+++ b/crates/python/src/compiler/quilc.rs
@@ -193,7 +193,7 @@ impl PyQuilcClient {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (quil, target, client, options = None))]
     #[tracing::instrument(skip_all)]

--- a/crates/python/src/executable.rs
+++ b/crates/python/src/executable.rs
@@ -92,7 +92,7 @@ macro_rules! py_job_handle {
     }};
 }
 
-#[pyo3_opentelemetry::pypropagate(exclude(new))]
+#[pyo3_opentelemetry::pypropagate(exclude(new), on_context_extraction_failure = "ignore")]
 #[pymethods]
 impl PyExecutable {
     #[new]

--- a/crates/python/src/qpu/api.rs
+++ b/crates/python/src/qpu/api.rs
@@ -81,7 +81,7 @@ py_function_sync_async! {
     /// * an engagement is not available
     /// * an RPCQ client cannot be built
     /// * the program cannot be submitted
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (program, patch_values, quantum_processor_id = None, client = None, execution_options = None))]
     async fn submit(
@@ -115,7 +115,7 @@ py_function_sync_async! {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (program, patch_values, quantum_processor_id = None, client = None, execution_options = None))]
     async fn submit_with_parameter_batch(
@@ -358,7 +358,7 @@ py_function_sync_async! {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (job_id, quantum_processor_id = None, client = None, execution_options = None))]
     async fn retrieve_results(

--- a/crates/python/src/qpu/translation.rs
+++ b/crates/python/src/qpu/translation.rs
@@ -30,7 +30,7 @@ create_init_submodule! {
 py_function_sync_async! {
     /// Query the QCS API for Quil-T calibrations.
     /// If `None`, the default `timeout` used is 10 seconds.
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (quantum_processor_id, client = None, timeout = None))]
     async fn get_quilt_calibrations(
@@ -177,7 +177,7 @@ py_function_sync_async! {
     /// # Errors
     ///
     /// Returns a [`TranslationError`] if translation fails.
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (native_quil, num_shots, quantum_processor_id, client = None, translation_options = None))]
     async fn translate(

--- a/crates/python/src/qvm/api.rs
+++ b/crates/python/src/qvm/api.rs
@@ -138,7 +138,7 @@ py_wrap_data_struct! {
 impl_repr!(PyMultishotResponse);
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (request, client, options = None))]
     #[tracing::instrument(skip_all)]
@@ -202,7 +202,7 @@ impl PyMultishotMeasureRequest {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (request, client, options = None))]
     #[tracing::instrument(skip_all)]
@@ -236,7 +236,7 @@ impl PyExpectationRequest {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (request, client, options = None))]
     #[tracing::instrument(skip_all)]
@@ -277,7 +277,7 @@ impl PyWavefunctionRequest {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[pyo3(signature = (request, client, options = None))]
     #[tracing::instrument(skip_all)]

--- a/crates/python/src/qvm/mod.rs
+++ b/crates/python/src/qvm/mod.rs
@@ -243,7 +243,7 @@ impl PyQvmOptions {
 }
 
 py_function_sync_async! {
-    #[pyo3_opentelemetry::pypropagate]
+    #[pyo3_opentelemetry::pypropagate(on_context_extraction_failure="ignore")]
     #[pyfunction]
     #[tracing::instrument(skip_all)]
     async fn run(


### PR DESCRIPTION
The default behavior or `pypropagate` is to eprintln errors - this includes the case where any upstream packages don't have Python `opentelemetry` installed. This doesn't actually raise, but it is noisy and annoying.

This changes the behavior to ignore context propagation failures. In the future, I'll support some more discerning options, so for instance import errors can be ignored (as they most often should), but any other error can be raise.