### PR TITLE
ci: Update deny.toml to match new specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"

--- a/crates/lib/Makefile.toml
+++ b/crates/lib/Makefile.toml
@@ -3,12 +3,12 @@ RUST_BACKTRACE = 0
 CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = "--features otel-tracing,libquil"  # Disable --all-features to avoid manual tests in CI for now
 
 [tasks.pre-test]
-command = "docker-compose"
-args = ["up", "-d"]
+command = "docker"
+args = ["compose", "up", "-d"]
 
 [tasks.post-test]
-command = "docker-compose"
-args = ["down"]
+command = "docker"
+args = ["compose", "down"]
 
 [tasks.serve-docs]
 command = "cargo"

--- a/crates/python/Makefile.toml
+++ b/crates/python/Makefile.toml
@@ -2,8 +2,8 @@
 RUST_BACKTRACE = 0
 
 [tasks.pre-test-docker-up]
-command = "docker-compose"
-args = ["up", "-d"]
+command = "docker"
+args = ["compose", "up", "-d"]
 
 [tasks.poetry-install]
 command = "poetry"
@@ -18,8 +18,8 @@ command = "poetry"
 args = ["run", "black", "qcs_sdk/_tracing_subscriber"]
 
 [tasks.post-test]
-command = "docker-compose"
-args = ["down"]
+command = "docker"
+args = ["compose", "down"]
 
 [tasks.test]
 command = "poetry"
@@ -48,9 +48,9 @@ command = "poetry"
 args = [
     "run",
     "stubtest",
-    "--allowlist", 
+    "--allowlist",
     ".stubtest-allowlist",
-    "--allowlist", 
+    "--allowlist",
     "./qcs_sdk/_tracing_subscriber/.stubtest-allowlist",
     "qcs_sdk"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -6,69 +6,97 @@
 # * allow - No warning or error will be produced, though in some cases a note
 # will be
 
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = true
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory database is cloned/fetched into
-db-path = "~/.cargo/advisory-db"
-# The url(s) of the advisory databases to use
-db-urls = ["https://github.com/rustsec/advisory-db"]
-# The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
-# The lint level for crates that have been yanked from their source registry
-yanked = "deny"
-# The lint level for crates with security notices.
-notice = "deny"
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
 ignore = [
-    "RUSTSEC-2023-0052",  # Introduced by transitive dependency `webpki`.
-                          # `hyper-proxy`, then `qcs-api-client-rust` need to update in order to remove
-                          # `webpki`.
-    "RUSTSEC-2024-0006",  # Introduced by bindgen/shlex with no valid upgrade path.
-    "RUSTSEC-2023-0055",  # there isn't a newer version of lexical with a fix
-    "RUSTSEC-2024-0336",  # needs to be address in qcs-api-client-rust.
+    { id = "RUSTSEC-2023-0052", reason = "Introduced by transitive dependency `webpki`. `hyper-proxy`, then `qcs-api-client-rust` need to update in order to remove" },
+    # { id = "RUSTSEC-2024-0320", reason = "yaml-rust is an unmaintained crate introduced by dev-dependency insta" },
+    { id = "RUSTSEC-2024-0336", reason = "introduced by hyper, a transitive dependency of qcs-api-client-grpc" },
+    { id = "RUSTSEC-2023-0055", reason = "introduced by lexical, a transitive dependency of quil-rs" },
+    { id = "RUSTSEC-2021-0145", reason = "introduced by atty, a transitive dependency of multiple dependencies, with no upgrade path" },
+    { id = "RUSTSEC-2024-0006", reason = "introduced by shlex, a transitive dependency of bindgen with no upgrade path" },
+    { id = "RUSTSEC-2021-0139", reason = "ansi_term is unmaintained, but used by clap" },
 ]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-unlicensed = "deny"
-allow = [
-  "Apache-2.0",
-  "Apache-2.0 WITH LLVM-exception",
-  "ISC",
-  "MIT",
-  "OpenSSL",
-  "BSD-2-Clause",
-  "BSD-3-Clause",
-  "Unicode-DFS-2016",
-  "Unicode-3.0",
-]
-# List of explictly disallowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-  #"Nokia",
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "ISC",
+    "MIT",
+    "OpenSSL",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "CC0-1.0",
 ]
-# Lint level for licenses considered copyleft
-copyleft = "deny"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -76,35 +104,117 @@ default = "deny"
 confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = [{ allow = ["MPL-2.0"], name = "webpki-roots", version = "*" }]
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
+   { allow = ["MPL-2.0"], crate = "webpki-roots" }
+]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
 [[licenses.clarify]]
-name = "ring"
-version = "*"
+crate = "ring"
+# The SPDX expression for the license requirements of the crate
 expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
-# published to private registries
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
 ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
 
 # This section is considered when running `cargo deny check bans`.
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
+# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
-wildcards = "deny"
+# Lint level for when a crate version requirement is `*`
+wildcards = "warn"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
 highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
 skip-tree = [
-  { name = "toml", version = "*", depth = 20 },
-  { name = "warp", version = "*", depth = 20 },              # Only used for development
-  { name = "hermit-abi", version = "*", depth = 20 },        # Only used for development
-  { name = "hyper-rustls", version = "<=0.23", depth = 20 }, # `hyper-proxy` relies on an older version than `rqwest`
-  { name = "itertools", version = "*", depth = 20 },         # `quil-rs` and various transitive dependencies depend on different versions
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+    { crate = "toml", depth = 20 },
+    { crate = "warp", depth = 20 },              # Only used for development
+    { crate = "hermit-abi", depth = 20 },        # Only used for development
+    { crate = "hyper-rustls", depth = 20 },      # `hyper-proxy` relies on an older version than `reqwest`
+    { crate = "itertools", depth = 20 },         # `quil-rs` and various transitive dependencies depend on different versions
+    { crate = "hashbrown", depth = 20 },         # `indexmap` and `cached` depend on different versions
 ]
 
 # This section is considered when running `cargo deny check sources`.
@@ -117,7 +227,16 @@ unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = ["https://github.com/rigetti/quil-rs"]
 # List of URLs for allowed crate registries. Defaults to the crates.io index
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = ["https://github.com/rigetti/quil-rs"]
+
+[sources.allow-org]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []


### PR DESCRIPTION
closes #496; cargo-deny recently shipped breaking changes to their deny.toml spec, so I've updated ours to match.