### PR TITLE
fix: ExecutionOptions::default() now respects defaults used in ExecutionOptionsBuilder::default()

### DIFF
--- a/crates/lib/src/qpu/api.rs
+++ b/crates/lib/src/qpu/api.rs
@@ -327,11 +327,11 @@ pub type QpuConnectionOptions = ExecutionOptions;
 /// Builder for setting up [`QpuConnectionOptions`].
 pub type QpuConnectionOptionsBuilder = ExecutionOptionsBuilder;
 
-/// Options avaialable when executing a job on a QPU.
+/// Options available when executing a job on a QPU.
 ///
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ExecutionOptionsBuilder`]
 /// to build a custom set of options.
-#[derive(Builder, Clone, Debug, Default, PartialEq)]
+#[derive(Builder, Clone, Debug, PartialEq)]
 pub struct ExecutionOptions {
     #[doc = "The [`ConnectionStrategy`] to use to establish a connection to the QPU."]
     #[builder(default)]
@@ -339,14 +339,22 @@ pub struct ExecutionOptions {
     #[doc = "The timeout to use for the request, defaults to 30 seconds. If set to `None`, then there is no timeout."]
     #[builder(default = "Some(Duration::from_secs(30))")]
     timeout: Option<Duration>,
-    #[doc = "Options avaialable when executing a job on a QPU, particular to the execution service's API."]
+    #[doc = "Options available when executing a job on a QPU, particular to the execution service's API."]
     #[builder(default = "None")]
     api_options: Option<InnerApiExecutionOptions>,
 }
 
+impl Default for ExecutionOptions {
+    fn default() -> Self {
+        ExecutionOptionsBuilder::default().build().expect(
+            "Should be able to derive a default set of the ExecutionOptions from the builder.",
+        )
+    }
+}
+
 impl Eq for ExecutionOptions {}
 
-/// Options avaialable when executing a job on a QPU, particular to the execution service's API.
+/// Options available when executing a job on a QPU, particular to the execution service's API.
 /// This is a conventent alias for [`InnerApiExecutionOptions`] which provides a builder.
 ///
 /// Use [`Default`] to get a reasonable set of defaults, or start with [`ApiExecutionOptionsBuilder`]
@@ -701,4 +709,19 @@ pub enum QpuApiError {
         /// identifier into a known status type.
         message: String,
     },
+}
+
+#[cfg(test)]
+mod test {
+    use crate::qpu::api::ExecutionOptions;
+
+    use super::ExecutionOptionsBuilder;
+
+    #[test]
+    fn test_default_execution_options() {
+        assert_eq!(
+            ExecutionOptions::default(),
+            ExecutionOptionsBuilder::default().build().unwrap(),
+        );
+    }
 }


### PR DESCRIPTION
closes #498 