### PR TITLE
chore: update github actions knope version to 0.7.2

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.PAT }}
     - name: Install Knope
-      uses: knope-dev/action@v2.0.0
+      uses: knope-dev/action@v2.1.0
       with:
         version: 0.18.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install Knope
       uses: knope-dev/action@v2.0.0
       with:
-        version: 0.7.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+        version: 0.18.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |
         git config --global user.name "${{ github.triggering_actor }}"
         git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,9 +25,9 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.PAT }}
     - name: Install Knope
-      uses: knope-dev/action@v2.1.0
+      uses: knope-dev/action@v2.0.0
       with:
-        version: 0.18.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+        version: 0.7.2 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - run: |
         git config --global user.name "${{ github.triggering_actor }}"
         git config --global user.email "${{ github.triggering_actor}}@users.noreply.github.com"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Knope
         uses: knope-dev/action@v2.0.0
         with:
-          version: 0.7.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+          version: 0.7.2 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
       - name: Display Pending Release
         run: knope release --dry-run
         env:


### PR DESCRIPTION
Recently #519 failed because of https://github.com/knope-dev/action/issues/10

This fixes that by using the compatible https://github.com/knope-dev/knope/releases/tag/v0.7.2 tag