### PR TITLE
fix(python): update workflow action version for download/upload artifact

### DIFF
--- a/.github/action-common-python-release/action.yml
+++ b/.github/action-common-python-release/action.yml
@@ -6,6 +6,8 @@ inputs:
     required: true
     description: "Either `qcs-sdk-python` or `qcs-sdk-python-grpc-web`"
 
+  artifact-key:
+    description: "Unique upload-artifact key. Example: 'macos' or 'linux-x86_64'"
   python-architecture:
     description: "Python architecture used for script steps"
   rust-target:
@@ -17,7 +19,6 @@ inputs:
     description: "Additional maturin command arguments"
   maturin-target:
     description: "Rust target used for maturin compilation"
-
 
 runs:
   using: "composite"
@@ -60,7 +61,7 @@ runs:
     run: |
       pip install ${{ inputs.package-name }} --find-links dist --force-reinstall
   - name: Upload wheels
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
-      name: wheels_${{ inputs.package-name }}
-      path: dist
+      name: wheels_${{ inputs.package-name }}-${{ inputs.artifact-key }}
+      path: dist/

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -159,4 +159,4 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         command: upload
-        args: --skip-existing wheels_${{ matrix.package-name }}/*
+        args: --skip-existing wheels/*

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -40,6 +40,7 @@ jobs:
         version: '3.20.1'
     - uses: ./.github/action-common-python-release
       with:
+        artifact-key: macos
         package-name: ${{ matrix.package-name }}
         maturin-target: universal2-apple-darwin
 
@@ -60,6 +61,7 @@ jobs:
         version: '3.20.1'
     - uses: ./.github/action-common-python-release
       with:
+        artifact-key: linux-${{ matrix.target }}
         package-name: qcs-sdk-python
         maturin-target: ${{ matrix.target }}
 
@@ -80,6 +82,7 @@ jobs:
         version: '3.20.1'
     - uses: ./.github/action-common-python-release
       with:
+        artifact-key: linux-${{ matrix.target }}
         package-name: qcs-sdk-python-grpc-web
         maturin-target: ${{ matrix.target }}
 
@@ -102,6 +105,7 @@ jobs:
         version: '3.20.1'
     - uses: ./.github/action-common-python-release
       with:
+        artifact-key: windows
         package-name: ${{ matrix.package-name }}
         python-architecture: x64
         rust-target: x86_64-pc-windows-msvc
@@ -123,6 +127,7 @@ jobs:
         version: '3.20.1'
     - uses: ./.github/action-common-python-release
       with:
+        artifact-key: sdist
         package-name: ${{ matrix.package-name }}
         maturin-command: sdist
 
@@ -143,7 +148,13 @@ jobs:
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
+      with:
+        path: wheels
+        pattern: wheels_${{ matrix.package-name }}-*
+        merge-multiple: true
+    - name: List wheels to upload
+      run: ls -R wheels
     - name: Publish to PyPI
       uses: messense/maturin-action@v1
       with:


### PR DESCRIPTION
Should fix <html><body><a href="https://github.com/rigetti/qcs-sdk-rust/actions/runs/13041993520">[python 0.21.7 · rigetti/qcs-sdk-rust@dcd5f1e](https://github.com/rigetti/qcs-sdk-rust/actions/runs/13041993520)</a></body></html>

```
Error: This request has been automatically failed because
it uses a deprecated version of `actions/download-artifact: v3`.

Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```