### PR TITLE
fix: test all python releases individually, use manylinux 2_34

### DIFF
--- a/.github/action-common-python-release/action.yml
+++ b/.github/action-common-python-release/action.yml
@@ -8,6 +8,8 @@ inputs:
 
   artifact-key:
     description: "Unique upload-artifact key. Example: 'macos' or 'linux-x86_64'"
+  python-version:
+    description: "Python version used for script steps and wheel"
   python-architecture:
     description: "Python architecture used for script steps"
   rust-target:
@@ -27,7 +29,7 @@ runs:
   steps:
   - uses: actions/setup-python@v4
     with:
-      python-version: "3.12"
+      python-version: ${{ inputs.python-version }}
       architecture: ${{ inputs.python-architecture }}
   - name: Install Rust toolchain
     uses: actions-rs/toolchain@v1
@@ -46,7 +48,7 @@ runs:
       command: ${{ inputs.maturin-command }}
       target: ${{ inputs.maturin-target }}
       container: ${{ inputs.maturin-container }}
-      args: -i 3.8 3.9 3.10 3.11 3.12 --release --manifest-path crates/python/Cargo.toml --out dist ${{ inputs.package-name == 'qcs-sdk-python-grpc-web' && '-F grpc-web' || '' }}
+      args: --release --manifest-path crates/python/Cargo.toml --out dist ${{ inputs.package-name == 'qcs-sdk-python-grpc-web' && '-F grpc-web' || '' }}
       docker-options: -e CI
   - if: inputs.maturin-command == 'sdist'
     name: Maturin - Source Distribution
@@ -67,5 +69,5 @@ runs:
   - name: Upload wheels
     uses: actions/upload-artifact@v4
     with:
-      name: wheels_${{ inputs.package-name }}-${{ inputs.artifact-key }}
+      name: wheels_${{ inputs.package-name }}-${{ inputs.python-version }}-${{ inputs.artifact-key }}
       path: dist/

--- a/.github/action-common-python-release/action.yml
+++ b/.github/action-common-python-release/action.yml
@@ -44,7 +44,7 @@ runs:
     name: Maturin - Build
     uses: messense/maturin-action@v1
     with:
-      manylinux: '2_28'
+      manylinux: '2_34'
       command: ${{ inputs.maturin-command }}
       target: ${{ inputs.maturin-target }}
       container: ${{ inputs.maturin-container }}
@@ -54,7 +54,7 @@ runs:
     name: Maturin - Source Distribution
     uses: messense/maturin-action@v1
     with:
-      manylinux: '2_28'
+      manylinux: '2_34'
       command: ${{ inputs.maturin-command }}
       target: ${{ inputs.maturin-target }}
       container: ${{ inputs.maturin-container }}

--- a/.github/action-common-python-release/action.yml
+++ b/.github/action-common-python-release/action.yml
@@ -48,7 +48,7 @@ runs:
       command: ${{ inputs.maturin-command }}
       target: ${{ inputs.maturin-target }}
       container: ${{ inputs.maturin-container }}
-      args: --release --manifest-path crates/python/Cargo.toml --out dist ${{ inputs.package-name == 'qcs-sdk-python-grpc-web' && '-F grpc-web' || '' }}
+      args: -i ${{ inputs.python-version }} --release --manifest-path crates/python/Cargo.toml --out dist ${{ inputs.package-name == 'qcs-sdk-python-grpc-web' && '-F grpc-web' || '' }}
       docker-options: -e CI
   - if: inputs.maturin-command == 'sdist'
     name: Maturin - Source Distribution

--- a/.github/workflows/check-release-python.yml
+++ b/.github/workflows/check-release-python.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -37,7 +38,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -59,7 +61,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -81,7 +84,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -103,7 +107,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -125,7 +130,8 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - name: Enable long path support
       run: |
@@ -153,7 +159,8 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc

--- a/.github/workflows/check-release-python.yml
+++ b/.github/workflows/check-release-python.yml
@@ -1,5 +1,3 @@
-name: Release Python
-
 name: Check Release Python
 on:
   push:

--- a/.github/workflows/check-release-python.yml
+++ b/.github/workflows/check-release-python.yml
@@ -1,0 +1,171 @@
+name: Release Python
+
+name: Check Release Python
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    env:
+      CXXFLAGS: "-std=c++11 -stdlib=libc++"
+    strategy:
+      fail-fast: false
+      matrix:
+        package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: macos
+        package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
+        maturin-target: universal2-apple-darwin
+        maturin-container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
+
+  linux-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CXXFLAGS: "-std=c++11"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: linux-x86_64
+        package-name: qcs-sdk-python
+        python-version: ${{ matrix.python-version }}
+        maturin-target: x86_64
+
+  linux-aarch64:
+    runs-on: ubuntu-24.04-arm
+    env:
+      CXXFLAGS: "-std=c++11"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: linux-aarch64
+        package-name: qcs-sdk-python
+        python-version: ${{ matrix.python-version }}
+        maturin-target: aarch64
+
+  linux-grpc-web-x86_64:
+    runs-on: ubuntu-latest
+    env:
+      CXXFLAGS: "-std=c++11"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: linux-grpc-web-x86_64
+        package-name: qcs-sdk-python-grpc-web
+        python-version: ${{ matrix.python-version }}
+        maturin-target: x86_64
+
+  linux-grpc-web-ppc64le:
+    runs-on: ubuntu-latest
+    env:
+      CXXFLAGS: "-std=c++11"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: linux-grpc-web-ppc64le
+        package-name: qcs-sdk-python-grpc-web
+        python-version: ${{ matrix.python-version }}
+        maturin-target: ppc64le
+        maturin-container: ghcr.io/rust-cross/manylinux_2_28-cross:ppc64le
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - name: Enable long path support
+      run: |
+        reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+        git config --system core.longpaths true
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: windows
+        package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
+        python-architecture: x64
+        rust-target: x86_64-pc-windows-msvc
+
+  sdist:
+    runs-on: ubuntu-latest
+    env:
+      CXXFLAGS: "-std=c++11"
+    strategy:
+      fail-fast: false
+      matrix:
+        package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        version: '3.20.1'
+    - uses: ./.github/action-common-python-release
+      with:
+        artifact-key: sdist
+        package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
+        maturin-command: sdist

--- a/.github/workflows/check-release-python.yml.disabled
+++ b/.github/workflows/check-release-python.yml.disabled
@@ -1,3 +1,4 @@
+# use this for testing when necessary
 name: Check Release Python
 on:
   push:
@@ -14,8 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -38,8 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -53,6 +52,7 @@ jobs:
         package-name: qcs-sdk-python
         python-version: ${{ matrix.python-version }}
         maturin-target: x86_64
+        maturin-container: quay.io/pypa/manylinux_2_34_x86_64:latest
 
   linux-aarch64:
     runs-on: ubuntu-24.04-arm
@@ -61,8 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -84,8 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -107,8 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -130,8 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Enable long path support
       run: |
@@ -159,8 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -42,6 +43,7 @@ jobs:
       with:
         artifact-key: macos
         package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
         maturin-target: universal2-apple-darwin
         maturin-container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
 
@@ -50,6 +52,9 @@ jobs:
     needs: [is-python-release, should-publish-wheels]
     env:
       CXXFLAGS: "-std=c++11"
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -61,6 +66,7 @@ jobs:
       with:
         artifact-key: linux-x86_64
         package-name: qcs-sdk-python
+        python-version: ${{ matrix.python-version }}
         maturin-target: x86_64
 
   linux-aarch64:
@@ -68,6 +74,9 @@ jobs:
     needs: [is-python-release, should-publish-wheels]
     env:
       CXXFLAGS: "-std=c++11"
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -79,6 +88,7 @@ jobs:
       with:
         artifact-key: linux-aarch64
         package-name: qcs-sdk-python
+        python-version: ${{ matrix.python-version }}
         maturin-target: aarch64
 
   linux-grpc-web-x86_64:
@@ -86,6 +96,9 @@ jobs:
     needs: [is-python-release, should-publish-wheels]
     env:
       CXXFLAGS: "-std=c++11"
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -97,6 +110,7 @@ jobs:
       with:
         artifact-key: linux-grpc-web-x86_64
         package-name: qcs-sdk-python-grpc-web
+        python-version: ${{ matrix.python-version }}
         maturin-target: x86_64
 
   linux-grpc-web-ppc64le:
@@ -104,6 +118,9 @@ jobs:
     needs: [is-python-release, should-publish-wheels]
     env:
       CXXFLAGS: "-std=c++11"
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -115,6 +132,7 @@ jobs:
       with:
         artifact-key: linux-grpc-web-ppc64le
         package-name: qcs-sdk-python-grpc-web
+        python-version: ${{ matrix.python-version }}
         maturin-target: ppc64le
         maturin-container: ghcr.io/rust-cross/manylinux_2_28-cross:ppc64le
 
@@ -124,6 +142,7 @@ jobs:
     strategy:
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - name: Enable long path support
       run: |
@@ -139,6 +158,7 @@ jobs:
       with:
         artifact-key: windows
         package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
         python-architecture: x64
         rust-target: x86_64-pc-windows-msvc
 
@@ -150,6 +170,7 @@ jobs:
     strategy:
       matrix:
         package-name: [qcs-sdk-python, qcs-sdk-python-grpc-web]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
@@ -161,6 +182,7 @@ jobs:
       with:
         artifact-key: sdist
         package-name: ${{ matrix.package-name }}
+        python-version: ${{ matrix.python-version }}
         maturin-command: sdist
 
   publish:


### PR DESCRIPTION
https://github.com/rigetti/qcs-sdk-rust/pull/532 wheels apparently aren't building correctly in `python 3.9` this will at least test installing them in all environments.