### PR TITLE
fix(python): don't use compression when storing github actions artifacts

### DIFF
--- a/.github/action-common-python-release/action.yml
+++ b/.github/action-common-python-release/action.yml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: actions/setup-python@v4
+  - uses: actions/setup-python@v5
     with:
       python-version: ${{ inputs.python-version }}
       architecture: ${{ inputs.python-architecture }}
@@ -71,4 +71,5 @@ runs:
     with:
       name: wheels_${{ inputs.package-name }}-${{ inputs.python-version }}-${{ inputs.maturin-target }}-${{ inputs.artifact-key }}
       path: dist/
+      compression-level: 0
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -36,10 +36,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: macos
@@ -58,10 +58,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: linux-x86_64
@@ -80,10 +80,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: linux-aarch64
@@ -102,10 +102,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: linux-grpc-web-x86_64
@@ -124,10 +124,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: linux-grpc-web-ppc64le
@@ -149,10 +149,10 @@ jobs:
         git config --system core.longpaths true
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: windows
@@ -173,10 +173,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install protoc
-      uses: arduino/setup-protoc@v1
+      uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        version: '3.20.1'
+        version: '21.0'
     - uses: ./.github/action-common-python-release
       with:
         artifact-key: sdist


### PR DESCRIPTION
Update some actions versions to (hopefully) reduce warning spam, and set upload-artifacts compression level to 0