### PR TITLE
fix: put pyo3 behind feature flag for qcs crate

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -16,7 +16,7 @@ tracing-config = ["tracing", "qcs-api-client-common/tracing-config", "qcs-api-cl
 libquil = ["dep:libquil-sys"]
 grpc-web = ["qcs-api-client-grpc/grpc-web"]
 tracing-opentelemetry = ["tracing-config", "qcs-api-client-grpc/tracing-opentelemetry", "qcs-api-client-openapi/tracing-opentelemetry"]
-pyo3 = ["dep:pyo3"]
+python = ["dep:pyo3"]
 experimental = []
 
 [dependencies]

--- a/crates/lib/src/qpu/translation.rs
+++ b/crates/lib/src/qpu/translation.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashMap, time::Duration};
 
-#[cfg(feature = "pyo3")]
+#[cfg(feature = "python")]
 use pyo3::{exceptions::PyValueError, PyErr};
 use qcs_api_client_grpc::{
     models::controller::EncryptedControllerJob,
@@ -31,7 +31,7 @@ pub enum Error {
     ClientTimeout(#[from] Elapsed),
 }
 
-#[cfg(feature = "pyo3")]
+#[cfg(feature = "python")]
 impl From<Error> for PyErr {
     fn from(value: Error) -> Self {
         let message = value.to_string();

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib", "rlib"]
 async-trait = "0.1.73"
 futures-util = "0.3.24"
 # TODO #507: automatically update the version when publishing
-qcs = { version = "0.25", path = "../lib", features = ["tracing-opentelemetry", "experimental", "pyo3"] }
+qcs = { version = "0.25", path = "../lib", features = ["tracing-opentelemetry", "experimental", "python"] }
 qcs-api-client-common = { workspace = true, features = ["python"] }
 qcs-api-client-grpc.workspace = true
 qcs-api-client-openapi.workspace = true


### PR DESCRIPTION
The `pyo3` dependency for the `qcs` crate breaks one of our internal Docker builds and really isn't necessary by default, so I've put it behind a `"pyo3"` feature flag.