### PR TITLE
fix: use knope's native functionality for updating workspace dependencies

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -1,5 +1,9 @@
 [packages.lib]
-versioned_files = ["crates/lib/Cargo.toml"]
+versioned_files = [
+    "crates/lib/Cargo.toml",
+    "Cargo.lock",
+    { path = "crates/python/Cargo.toml", dependency = "qcs" },
+]
 changelog = "crates/lib/CHANGELOG.md"
 scopes = ["lib", "rust"]
 


### PR DESCRIPTION
should fix #507